### PR TITLE
feat: implement done legislative notices support with advanced search and bulk collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
   - [getDone](#getdone--promiseitable-data)
   - [getDoneContentHTML](#getdonecontenthtmlid-string--promisestring)
   - [getDoneContent](#getdonecontentid-string--promiseicontentdata)
+  - [search / searchDone](#searchquery-isearchquery--promiseisearchresult)
+  - [getPage / getDonePage](#getpagepageindex-number-pageunit-number--promiseitable-data)
+  - [getAllPages / getAllDonePages](#getallpagesquery-isearchquery-options-ibulkoptions--asyncgeneratorisearchresult)
 - [Examples](#examples)
 - [License](#license)
 
@@ -119,6 +122,52 @@ interface IContentData {
   referralDate: string | null; // 회부일
   noticePeriod: string | null; // 입법예고기간
   proposalSession: string | null; // 제안회기
+}
+```
+
+`ISearchResult`는 검색/페이지 조회 결과를 나타내는 인터페이스입니다.
+
+```typescript
+interface ISearchResult {
+  total: number; // 전체 건수
+  totalPages: number; // 전체 페이지 수
+  currentPage: number; // 현재 페이지
+  items: ITableData[]; // 현재 페이지 항목 목록
+}
+```
+
+`ISearchQuery`는 검색 필터 옵션을 나타내는 인터페이스입니다.
+
+```typescript
+interface ISearchQuery {
+  pageIndex?: number; // 페이지 번호 (기본값: 1)
+  pageUnit?: number; // 페이지당 항목 수 (5~9, 20, 30, 50, 100; 기본값: 10)
+  committeeId?: string; // 소관위원회 ID (예: '9700006' = 법제사법위원회)
+  billName?: string; // 법안명 검색어
+  represent?: string; // 대표발의자 검색어
+  proposers?: string; // 공동발의자 검색어 (쉼표 구분 AND 조건)
+  ppslRsonMnCn?: string; // 제안이유 검색어
+  sortCol?:
+    | 'BILL_NO'
+    | 'BILL_NAME'
+    | 'CURR_COMMITTEE'
+    | 'OPN_CNT'
+    | 'LGSLT_PA_RG_DT';
+  sortGbn?: 'DESC' | 'ASC';
+  // 종료된 입법예고 전용:
+  fromAge?: number; // 시작 대수 (예: 21)
+  toAge?: number; // 종료 대수 (예: 22)
+  billNo?: string; // 의안번호 검색어
+}
+```
+
+`IBulkOptions`는 대량 수집 시 동작을 제어하는 인터페이스입니다.
+
+```typescript
+interface IBulkOptions {
+  delayMs?: number; // 페이지 간 요청 지연 (밀리초, 기본값: 500)
+  concurrency?: number; // 동시 요청 수 (기본값: 1)
+  maxPages?: number; // 최대 수집 페이지 수 (기본값: 전체)
 }
 ```
 
@@ -238,6 +287,117 @@ console.log(content);
 
 ---
 
+### search(query?: ISearchQuery) => Promise\<ISearchResult>
+
+`search` 메서드는 진행 중인 입법 예고를 조건에 맞게 검색합니다. 검색 결과에는 총 건수, 페이지 정보, 항목 목록이 포함됩니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 기본 조회 (1페이지 10건)
+const result = await palCrawl.search();
+console.log(result.total, result.totalPages, result.items);
+
+// 법안명 필터 + 정렬
+const filtered = await palCrawl.search({
+  billName: '도로교통법',
+  sortCol: 'BILL_NAME',
+  sortGbn: 'ASC',
+  pageUnit: 20,
+});
+```
+
+### searchDone(query?: ISearchQuery) => Promise\<ISearchResult>
+
+`searchDone` 메서드는 종료된 입법 예고를 조건에 맞게 검색합니다. `fromAge`, `toAge`, `billNo` 필터를 추가로 지원합니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 22대 종료 입법예고만 조회
+const result = await palCrawl.searchDone({ fromAge: 22, toAge: 22 });
+console.log(result.total, result.items);
+```
+
+---
+
+### getPage(pageIndex: number, pageUnit?: number) => Promise\<ITableData[]>
+
+`getPage` 메서드는 진행 중인 입법 예고에서 특정 페이지의 항목을 가져옵니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+const page1 = await palCrawl.getPage(1); // 1페이지 (기본 10건)
+const page2 = await palCrawl.getPage(2, 20); // 2페이지, 20건씩
+```
+
+### getDonePage(pageIndex: number, pageUnit?: number) => Promise\<ITableData[]>
+
+`getDonePage` 메서드는 종료된 입법 예고에서 특정 페이지의 항목을 가져옵니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const page3 = await palCrawl.getDonePage(3);
+```
+
+---
+
+### getAllPages(query?: ISearchQuery, options?: IBulkOptions) => AsyncGenerator\<ISearchResult>
+
+`getAllPages` 메서드는 진행 중인 입법 예고를 여러 페이지에 걸쳐 순차적으로 수집하는 비동기 제너레이터입니다. `for await...of` 루프로 한 페이지씩 처리할 수 있습니다.
+
+- `delayMs` (기본값: 500): 페이지 요청 사이의 지연 시간(ms). 서버 부하를 줄이기 위해 설정하세요.
+- `concurrency` (기본값: 1): 동시에 요청할 페이지 수.
+- `maxPages` (기본값: 전체 페이지): 수집할 최대 페이지 수.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 처음 5 페이지를 순서대로 수집
+for await (const page of palCrawl.getAllPages(
+  {},
+  { maxPages: 5, delayMs: 300 },
+)) {
+  console.log(
+    `페이지 ${page.currentPage}/${page.totalPages}: ${page.items.length}건`,
+  );
+  for (const item of page.items) {
+    console.log(item.subject);
+  }
+}
+```
+
+### getAllDonePages(query?: ISearchQuery, options?: IBulkOptions) => AsyncGenerator\<ISearchResult>
+
+`getAllDonePages`는 종료된 입법 예고에 대한 대량 수집 제너레이터입니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 22대 종료 입법예고 전체 수집 (concurrency=2, 지연 200ms)
+for await (const page of palCrawl.getAllDonePages(
+  { fromAge: 22, toAge: 22 },
+  { concurrency: 2, delayMs: 200 },
+)) {
+  console.log(`${page.currentPage}/${page.totalPages}: ${page.items.length}건`);
+}
+```
+
+---
+
 ## Examples
 
 ### 기본 사용법
@@ -315,6 +475,60 @@ if (first?.contentId) {
   console.log(content.proposalReason);
   console.log(content.billNumber);
   console.log(content.noticePeriod);
+}
+```
+
+### 검색 필터를 사용해 법안 조회하기
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 법안명 검색
+const result = await palCrawl.search({ billName: '도로교통법', pageUnit: 20 });
+console.log(`총 ${result.total}건 (${result.totalPages}페이지)`);
+result.items.forEach((item) => console.log(item.subject));
+
+// 22대 종료 입법예고에서 의안번호로 검색
+const done = await palCrawl.searchDone({
+  fromAge: 22,
+  toAge: 22,
+  billNo: '2218',
+});
+done.items.forEach((item) => console.log(item.subject));
+```
+
+### 대량 수집 (getAllPages / getAllDonePages)
+
+```typescript
+import { PalCrawl, type ITableData } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const allItems: ITableData[] = [];
+
+// 진행 중인 입법예고 전체 페이지 수집 (500ms 지연)
+for await (const page of palCrawl.getAllPages({}, { delayMs: 500 })) {
+  allItems.push(...page.items);
+  console.log(`수집 중: ${page.currentPage}/${page.totalPages} 페이지`);
+}
+
+console.log(`전체 ${allItems.length}건 수집 완료`);
+```
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+
+// 처음 10 페이지만, 동시 2개 요청으로 빠르게 수집
+for await (const page of palCrawl.getAllDonePages(
+  { sortCol: 'LGSLT_PA_RG_DT', sortGbn: 'DESC' },
+  { maxPages: 10, concurrency: 2, delayMs: 200 },
+)) {
+  console.log(
+    `페이지 ${page.currentPage}: ${page.items.map((i) => i.subject).join(', ')}`,
+  );
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@
 - [Configuration](#configuration)
 - [Base Types](#base-types)
 - [Methods](#methods)
-  - [get](#get)
-  - [getContentHTML](#getcontenthtml--promisestring)
+  - [get](#get--promiseitable-data)
+  - [getContentHTML](#getcontenthtmlid-string--promisestring)
   - [getContent](#getcontentid-string--promiseicontentdata)
+  - [getDone](#getdone--promiseitable-data)
+  - [getDoneContentHTML](#getdonecontenthtmlid-string--promisestring)
+  - [getDoneContent](#getdonecontentid-string--promiseicontentdata)
 - [Examples](#examples)
 - [License](#license)
 
@@ -123,7 +126,7 @@ interface IContentData {
 
 ## Methods
 
-### get() => Promise<ITableData[]>
+### get() => Promise\<ITableData[]>
 
 `get` 메서드는 진행 중인 입법 예고 데이터를 가져옵니다.
 
@@ -140,7 +143,7 @@ console.log(table);
 
 ### getContentHTML(id: string) => Promise\<string>
 
-`getContentHTML` 메서드는 특정 의안 ID의 본문 페이지 HTML 원문을 가져옵니다.
+`getContentHTML` 메서드는 진행 중인 입법 예고 중 특정 의안 ID의 본문 페이지 HTML 원문을 가져옵니다.
 
 ```typescript
 import { PalCrawl } from 'pal-crawl';
@@ -176,6 +179,60 @@ console.log(content);
 //   referralDate: '2026-04-02',
 //   noticePeriod: '2026-04-02~2026-04-11',
 //   proposalSession: '제22대(2024~2028) 제433회'
+// }
+```
+
+### getDone() => Promise\<ITableData[]>
+
+`getDone` 메서드는 종료된 입법 예고 데이터를 가져옵니다.
+
+반환되는 각 항목에는 `contentId`가 포함되며, 이 값을 `getDoneContentHTML` 또는 `getDoneContent`에 전달해 본문 조회를 바로 수행할 수 있습니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const table = await palCrawl.getDone();
+
+console.log(table);
+```
+
+### getDoneContentHTML(id: string) => Promise\<string>
+
+`getDoneContentHTML` 메서드는 종료된 입법 예고 중 특정 의안 ID의 본문 페이지 HTML 원문을 가져옵니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const table = await palCrawl.getDone();
+
+const id = table[0]?.contentId;
+if (id) {
+  const contentHtml = await palCrawl.getDoneContentHTML(id);
+  console.log(contentHtml);
+}
+```
+
+### getDoneContent(id: string) => Promise\<IContentData>
+
+`getDoneContent` 메서드는 종료된 입법 예고 중 특정 의안 ID의 본문 페이지를 파싱해 JSON 객체(`IContentData`)로 반환합니다.
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const content = await palCrawl.getDoneContent(
+  'PRC_S2R6N0M3K2J3K1J5K3S8R3P4O3P5X6',
+);
+
+console.log(content);
+// {
+//   title: '[2218503] 전자장치 부착 등에 관한 법률 일부개정법률안 (김기현의원 등 10인)',
+//   proposalReason: '...',
+//   billNumber: '2218503',
+//   proposer: '김기현의원 등 10인',
+//   ...
 // }
 ```
 
@@ -241,6 +298,24 @@ const config: PalCrawlConfig = {
 
 const palCrawl = new PalCrawl(config);
 const data = await palCrawl.get();
+```
+
+### 종료된 입법예고 목록에서 본문 가져오기
+
+```typescript
+import { PalCrawl } from 'pal-crawl';
+
+const palCrawl = new PalCrawl();
+const table = await palCrawl.getDone();
+
+const first = table.find((item) => item.contentId);
+if (first?.contentId) {
+  const content = await palCrawl.getDoneContent(first.contentId);
+  console.log(content.title);
+  console.log(content.proposalReason);
+  console.log(content.billNumber);
+  console.log(content.noticePeriod);
+}
 ```
 
 ### 에러 처리

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pal-crawl",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pal-crawl",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pal-crawl",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "국회입법예고(pal.assembly.go.kr)의 진행 중인 입법 예고 크롤러",
   "license": "MIT",
   "author": "vientorepublic",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,5 +2,7 @@ export enum Config {
   DOMAIN = 'https://pal.assembly.go.kr',
   LIST_URL = '/napal/lgsltpa/lgsltpaOngoing/list.do',
   CONTENT_URL = '/napal/lgsltpa/lgsltpaOngoing/view.do',
+  DONE_LIST_URL = '/napal/lgsltpa/lgsltpaDone/list.do',
+  DONE_CONTENT_URL = '/napal/lgsltpa/lgsltpaDone/view.do',
   UserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@ export {
   type IContentData,
   type PalCrawlConfig,
 } from './pal';
+export { PalParser } from './parser';
 export { Config } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ export {
   type ITableData,
   type IAttachment,
   type IContentData,
+  type ISearchResult,
+  type ISearchQuery,
+  type IBulkOptions,
   type PalCrawlConfig,
 } from './pal';
 export { PalParser } from './parser';

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -1,202 +1,470 @@
 import { ITableData, PalCrawl, type PalCrawlConfig } from './pal';
+import { PalParser } from './parser';
 
-const FIXED_CONTENT_ID = 'PRC_W2W6V0D4D0B9C1B4B4Z6V2W0U7V2T9';
+const FIXED_ONGOING_CONTENT_ID = 'PRC_W2W6V0D4D0B9C1B4B4Z6V2W0U7V2T9';
+const FIXED_DONE_CONTENT_ID = 'PRC_S2R6N0M3K2J3K1J5K3S8R3P4O3P5X6';
+
 const SHOULD_DEBUG = process.env.PAL_CRAWL_TEST_DEBUG === '1';
 
 const debugLog = (label: string, value: unknown): void => {
-  if (!SHOULD_DEBUG) {
-    return;
-  }
+  if (!SHOULD_DEBUG) return;
   console.debug(label, JSON.stringify(value, null, 2));
 };
 
-let table: ITableData[];
-let listHtml = '';
-let contentHtml = '';
-let fixedContent: Awaited<ReturnType<PalCrawl['getContent']>>;
+// ─── HTML Fixtures ────────────────────────────────────────────────────────────
+
+const TABLE_ROW_HTML = `
+<table>
+  <tbody>
+    <tr>
+      <td>42</td>
+      <td class="td_block">
+        <a href="/napal/lgsltpa/lgsltpaOngoing/view.do?lgsltPaId=PRC_TEST000" class="board_subject">테스트 법률안 (홍길동의원 등 5인)</a>
+      </td>
+      <td>의원</td>
+      <td>법제사법위원회</td>
+      <td></td>
+      <td>
+        <a href="#">버튼</a>
+        <a href="https://example.com/file.hwp">hwp</a>
+        <a href="https://example.com/file.pdf">pdf</a>
+      </td>
+      <td></td>
+      <td>1,234</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+const TABLE_ROW_NO_LINK_HTML = `
+<table>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td class="td_block">
+        <a class="board_subject">링크없는 법률안</a>
+      </td>
+      <td>정부</td>
+      <td>기획재정위원회</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>0</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+const CONTENT_HTML = `
+<div class="legislation-heading">
+  <h3>[2218288] 조세특례제한법 일부개정법률안(윤한홍의원 등 10인)</h3>
+</div>
+<div class="board01 pr td_center board-added">
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">의안번호</th>
+        <th scope="col">제안자</th>
+        <th scope="col">제안일</th>
+        <th scope="col">소관위원회</th>
+        <th scope="col">회부일</th>
+        <th scope="col">입법예고기간</th>
+        <th scope="col">법률안원문</th>
+        <th scope="col">제안회기</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2218288</td>
+        <td>
+          윤한홍의원 등 10인
+          <a class="btn_sm" href="#">제안자목록</a>
+        </td>
+        <td>2026-04-01</td>
+        <td class="td_block">
+          기획재정위원회
+          <div class="m_subject">
+            <ul class="m_date">
+              <li>입법예고기간 : 2026-04-02~2026-04-11</li>
+            </ul>
+          </div>
+        </td>
+        <td>2026-04-02</td>
+        <td>2026-04-02~2026-04-11</td>
+        <td><a href="#">미리보기</a></td>
+        <td>제22대(2024~2028) 제433회</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="card-wrap">
+  <div class="item">
+    <h4>제안이유 및 주요내용</h4>
+    <div class="desc">
+      제안이유 및 주요내용
+      <br/>첫 번째 문장
+      <br/>두 번째 문장
+    </div>
+  </div>
+  <div class="item">
+    <h4>의견제출 방법</h4>
+    <div class="desc">국회 재정경제기획위원회</div>
+  </div>
+  <div class="item item-means">
+    <div class="desc">제출방법: 상단 의견등록 탭 사용</div>
+  </div>
+</div>
+`;
+
+// ─── PalParser ────────────────────────────────────────────────────────────────
+
+describe('PalParser', () => {
+  const parser = new PalParser();
+
+  describe('parseTable', () => {
+    test('returns [] for invalid html', () => {
+      expect(parser.parseTable('asdf')).toHaveLength(0);
+    });
+
+    test('returns [] for empty string', () => {
+      expect(parser.parseTable('')).toHaveLength(0);
+    });
+
+    test('parses all fields from a valid table row', () => {
+      const rows = parser.parseTable(TABLE_ROW_HTML);
+      expect(rows).toHaveLength(1);
+      const row = rows[0];
+      expect(row.num).toBe(42);
+      expect(row.subject).toBe('테스트 법률안 (홍길동의원 등 5인)');
+      expect(row.proposerCategory).toBe('의원');
+      expect(row.committee).toBe('법제사법위원회');
+      expect(row.numComments).toBe(1234);
+      expect(row.link).toContain('PRC_TEST000');
+      expect(row.contentId).toBe('PRC_TEST000');
+      expect(row.attachments.hwpFile).toBe('https://example.com/file.hwp');
+      expect(row.attachments.pdfFile).toBe('https://example.com/file.pdf');
+    });
+
+    test('sets link to empty string and contentId to null when anchor has no href', () => {
+      const rows = parser.parseTable(TABLE_ROW_NO_LINK_HTML);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].link).toBe('');
+      expect(rows[0].contentId).toBeNull();
+    });
+
+    test('parses numComments with comma formatting as a plain number', () => {
+      const rows = parser.parseTable(TABLE_ROW_HTML);
+      expect(rows[0].numComments).toBe(1234);
+    });
+  });
+
+  describe('parseContent', () => {
+    test('parses all fields from a full fixture', () => {
+      const content = parser.parseContent(CONTENT_HTML);
+      expect(content.title).toContain('조세특례제한법 일부개정법률안');
+      expect(content.proposalReason).toBe('첫 번째 문장\n두 번째 문장');
+      expect(content.billNumber).toBe('2218288');
+      expect(content.proposer).toBe('윤한홍의원 등 10인');
+      expect(content.proposalDate).toBe('2026-04-01');
+      expect(content.committee).toBe('기획재정위원회');
+      expect(content.referralDate).toBe('2026-04-02');
+      expect(content.noticePeriod).toBe('2026-04-02~2026-04-11');
+      expect(content.proposalSession).toBe('제22대(2024~2028) 제433회');
+    });
+
+    test('strips the repeated heading line from proposal reason', () => {
+      const content = parser.parseContent(CONTENT_HTML);
+      // The desc starts with "제안이유 및 주요내용" which matches the heading — it must be stripped.
+      expect(content.proposalReason).not.toMatch(/제안이유/);
+    });
+
+    test('returns empty title and all nulls for empty html', () => {
+      const content = parser.parseContent('');
+      expect(content.title).toBe('');
+      expect(content.proposalReason).toBeNull();
+      expect(content.billNumber).toBeNull();
+      expect(content.proposer).toBeNull();
+      expect(content.proposalDate).toBeNull();
+      expect(content.committee).toBeNull();
+      expect(content.referralDate).toBeNull();
+      expect(content.noticePeriod).toBeNull();
+      expect(content.proposalSession).toBeNull();
+    });
+
+    test('falls back to h3 when .legislation-heading h3 is absent', () => {
+      const content = parser.parseContent('<h3>대체 제목</h3>');
+      expect(content.title).toBe('대체 제목');
+    });
+
+    test('returns null for all bill info fields when .board-added table is absent', () => {
+      const content = parser.parseContent(
+        '<div class="legislation-heading"><h3>제목</h3></div>',
+      );
+      expect(content.billNumber).toBeNull();
+      expect(content.proposer).toBeNull();
+      expect(content.proposalDate).toBeNull();
+      expect(content.committee).toBeNull();
+      expect(content.referralDate).toBeNull();
+      expect(content.noticePeriod).toBeNull();
+      expect(content.proposalSession).toBeNull();
+    });
+
+    test('returns null proposalReason when desc is empty', () => {
+      const content = parser.parseContent(`
+        <div class="card-wrap">
+          <div class="item">
+            <h4>제안이유 및 주요내용</h4>
+            <div class="desc"></div>
+          </div>
+        </div>
+      `);
+      expect(content.proposalReason).toBeNull();
+    });
+
+    test('keeps proposal reason as-is when first line does not repeat the heading', () => {
+      const content = parser.parseContent(`
+        <div class="card-wrap">
+          <div class="item">
+            <h4>제안이유 및 주요내용</h4>
+            <div class="desc">
+              본문 첫 줄
+              <br/>본문 두 번째 줄
+            </div>
+          </div>
+        </div>
+      `);
+      expect(content.proposalReason).toBe('본문 첫 줄\n본문 두 번째 줄');
+    });
+
+    test('ignores items without an h4 heading', () => {
+      expect(() =>
+        parser.parseContent(`
+          <div class="card-wrap">
+            <div class="item">
+              <div class="desc">heading 없는 항목</div>
+            </div>
+          </div>
+        `),
+      ).not.toThrow();
+    });
+  });
+});
+
+// ─── PalCrawl ─────────────────────────────────────────────────────────────────
 
 describe('PalCrawl', () => {
   const palCrawl = new PalCrawl();
 
-  beforeAll(async () => {
-    [listHtml, contentHtml] = await Promise.all([
-      palCrawl.getPalHTML(),
-      palCrawl.getContentHTML(FIXED_CONTENT_ID),
-    ]);
-    table = palCrawl.parseTable(listHtml);
-    fixedContent = palCrawl.parseContent(contentHtml);
-    debugLog('table', table);
-    debugLog('content', fixedContent);
-  });
+  // ── constructor ──────────────────────────────────────────────────────────────
 
-  test('getPalHTML: should be return string', () => {
-    expect(typeof listHtml).toBe('string');
-    expect(listHtml).not.toContain('�');
-  });
-  test('constructor: should use custom userAgent when provided in config', async () => {
-    const config: PalCrawlConfig = {
-      userAgent: 'Custom User Agent',
-    };
-    const palCrawl = new PalCrawl(config);
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
-  });
-  test('constructor: should use default userAgent when config is empty', async () => {
-    const palCrawl = new PalCrawl({});
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
-  });
-  test('constructor: should use default userAgent when no config provided', async () => {
-    const palCrawl = new PalCrawl();
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
-  });
-  test('parseTable: array length should be 0 when invalid html', () => {
-    const palCrawl = new PalCrawl();
-    const table = palCrawl.parseTable('asdf');
-    expect(table).toHaveLength(0);
-  });
-  test('parseContent: should parse title, reason, and bill information table fields', () => {
-    const palCrawl = new PalCrawl();
-    const html = `
-      <div class="legislation-heading">
-        <h3>[2218288] 조세특례제한법 일부개정법률안(윤한홍의원 등 10인)</h3>
-      </div>
-      <div class="board01 pr td_center board-added">
-        <table>
-          <thead>
-            <tr>
-              <th scope="col">의안번호</th>
-              <th scope="col">제안자</th>
-              <th scope="col">제안일</th>
-              <th scope="col">소관위원회</th>
-              <th scope="col">회부일</th>
-              <th scope="col">입법예고기간</th>
-              <th scope="col">법률안원문</th>
-              <th scope="col">제안회기</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>2218288</td>
-              <td>
-                윤한홍의원 등 10인
-                <a class="btn_sm" href="#">제안자목록</a>
-              </td>
-              <td>2026-04-01</td>
-              <td class="td_block">
-                기획재정위원회
-                <div class="m_subject">
-                  <ul class="m_date">
-                    <li>입법예고기간 : 2026-04-02~2026-04-11</li>
-                  </ul>
-                </div>
-              </td>
-              <td>2026-04-02</td>
-              <td>2026-04-02~2026-04-11</td>
-              <td><a href="#">미리보기</a></td>
-              <td>제22대(2024~2028) 제433회</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="card-wrap">
-        <div class="item">
-          <h4>제안이유 및 주요내용</h4>
-          <div class="desc">
-            제안이유 및 주요내용
-            <br/>첫 번째 문장
-            <br/>두 번째 문장
-          </div>
-        </div>
-        <div class="item">
-          <h4>의견제출 방법</h4>
-          <div class="desc">국회 재정경제기획위원회</div>
-        </div>
-        <div class="item item-means">
-          <div class="desc">제출방법: 상단 의견등록 탭 사용</div>
-        </div>
-      </div>
-    `;
+  describe('constructor', () => {
+    test('creates instance without config', () => {
+      expect(new PalCrawl()).toBeInstanceOf(PalCrawl);
+    });
 
-    const content = palCrawl.parseContent(html);
+    test('creates instance with empty config object', () => {
+      expect(new PalCrawl({})).toBeInstanceOf(PalCrawl);
+    });
 
-    expect(content.title).toContain('조세특례제한법 일부개정법률안');
-    expect(content.proposalReason).toBe('첫 번째 문장\n두 번째 문장');
-    expect(content.billNumber).toBe('2218288');
-    expect(content.proposer).toBe('윤한홍의원 등 10인');
-    expect(content.proposalDate).toBe('2026-04-01');
-    expect(content.committee).toBe('기획재정위원회');
-    expect(content.referralDate).toBe('2026-04-02');
-    expect(content.noticePeriod).toBe('2026-04-02~2026-04-11');
-    expect(content.proposalSession).toBe('제22대(2024~2028) 제433회');
-  });
-  test('getContentHTML: should prefetch real content html by fixed id', () => {
-    expect(typeof contentHtml).toBe('string');
-    expect(contentHtml.length).toBeGreaterThan(0);
-  });
+    test('accepts custom userAgent', () => {
+      expect(new PalCrawl({ userAgent: 'Custom Agent' })).toBeInstanceOf(
+        PalCrawl,
+      );
+    });
 
-  test('getContent: should parse prefetched content html by fixed id', () => {
-    const content = fixedContent;
+    test('accepts custom timeout', () => {
+      expect(new PalCrawl({ timeout: 5000 })).toBeInstanceOf(PalCrawl);
+    });
 
-    expect(content.title.length).toBeGreaterThan(0);
-    expect(content.proposalReason).not.toBeNull();
-    expect(content.proposalReason?.length ?? 0).toBeGreaterThan(0);
-    expect(content.billNumber).not.toBeNull();
-    expect(content.proposer).not.toBeNull();
-    expect(content.proposalDate).not.toBeNull();
-    expect(content.committee).not.toBeNull();
-    expect(content.referralDate).not.toBeNull();
-    expect(content.noticePeriod).not.toBeNull();
-    expect(content.proposalSession).not.toBeNull();
-    expect(content.title).not.toContain('�');
-    expect(content.proposalReason ?? '').not.toContain('�');
-  });
-  test('get: array length should be 10', async () => {
-    expect(table).toHaveLength(10);
-  });
-  test('get: URL string of the attachment object should not be empty', () => {
-    table.forEach((e) => {
-      expect(e.attachments.pdfFile).not.toBe('');
-      expect(e.attachments.hwpFile).not.toBe('');
-      expect(e.subject).not.toContain('�');
-      expect(e.proposerCategory).not.toContain('�');
-      expect(e.committee).not.toContain('�');
-      expect(e.contentId).not.toBeNull();
-      expect(e.contentId?.startsWith('PRC_')).toBe(true);
+    test('accepts custom retryCount', () => {
+      expect(new PalCrawl({ retryCount: 5 })).toBeInstanceOf(PalCrawl);
+    });
+
+    test('accepts custom headers', () => {
+      expect(
+        new PalCrawl({ customHeaders: { 'Accept-Language': 'ko-KR' } }),
+      ).toBeInstanceOf(PalCrawl);
+    });
+
+    test('accepts all config options together', () => {
+      const config: PalCrawlConfig = {
+        userAgent: 'Custom Agent',
+        timeout: 15000,
+        retryCount: 2,
+        customHeaders: { Accept: 'application/json' },
+      };
+      expect(new PalCrawl(config)).toBeInstanceOf(PalCrawl);
     });
   });
-  test('constructor: should use custom timeout when provided', () => {
-    const config: PalCrawlConfig = {
-      timeout: 5000,
-    };
-    const palCrawl = new PalCrawl(config);
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
+
+  // ── parseTable / parseContent (delegation) ───────────────────────────────────
+
+  describe('parseTable', () => {
+    test('returns [] for invalid html', () => {
+      expect(palCrawl.parseTable('asdf')).toHaveLength(0);
+    });
+
+    test('delegates to PalParser and returns parsed rows', () => {
+      const rows = palCrawl.parseTable(TABLE_ROW_HTML);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].num).toBe(42);
+      expect(rows[0].subject).toBe('테스트 법률안 (홍길동의원 등 5인)');
+      expect(rows[0].contentId).toBe('PRC_TEST000');
+    });
   });
-  test('constructor: should use custom retryCount when provided', () => {
-    const config: PalCrawlConfig = {
-      retryCount: 5,
-    };
-    const palCrawl = new PalCrawl(config);
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
+
+  describe('parseContent', () => {
+    test('delegates to PalParser and returns parsed content', () => {
+      const content = palCrawl.parseContent(CONTENT_HTML);
+      expect(content.title).toContain('조세특례제한법 일부개정법률안');
+      expect(content.billNumber).toBe('2218288');
+      expect(content.proposer).toBe('윤한홍의원 등 10인');
+    });
   });
-  test('constructor: should use custom headers when provided', () => {
-    const config: PalCrawlConfig = {
-      customHeaders: {
-        'Accept-Language': 'ko-KR',
-        'Custom-Header': 'test-value',
-      },
-    };
-    const palCrawl = new PalCrawl(config);
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
+
+  // ── ongoing legislative notices (integration) ────────────────────────────────
+
+  describe('ongoing legislative notices', () => {
+    let listHtml = '';
+    let ongoingTable: ITableData[] = [];
+    let contentHtml = '';
+    let fixedContent: Awaited<ReturnType<PalCrawl['getContent']>>;
+
+    beforeAll(async () => {
+      [listHtml, contentHtml] = await Promise.all([
+        palCrawl.getPalHTML(),
+        palCrawl.getContentHTML(FIXED_ONGOING_CONTENT_ID),
+      ]);
+      ongoingTable = palCrawl.parseTable(listHtml);
+      fixedContent = palCrawl.parseContent(contentHtml);
+      debugLog('ongoingTable', ongoingTable);
+      debugLog('fixedContent', fixedContent);
+    });
+
+    test('getPalHTML: returns a non-garbled html string', () => {
+      expect(typeof listHtml).toBe('string');
+      expect(listHtml.length).toBeGreaterThan(0);
+      expect(listHtml).not.toContain('�');
+    });
+
+    test('get: returns 10 items per page', async () => {
+      const result = await palCrawl.get();
+      expect(result).toHaveLength(10);
+    });
+
+    test('get: each item has valid structure and no garbled text', () => {
+      ongoingTable.forEach((e) => {
+        expect(e.subject).not.toContain('�');
+        expect(e.proposerCategory).not.toContain('�');
+        expect(e.committee).not.toContain('�');
+        expect(e.attachments.pdfFile).not.toBe('');
+        expect(e.attachments.hwpFile).not.toBe('');
+        expect(e.contentId).not.toBeNull();
+        expect(e.contentId?.startsWith('PRC_')).toBe(true);
+      });
+    });
+
+    test('getContentHTML: returns non-empty html for known id', () => {
+      expect(typeof contentHtml).toBe('string');
+      expect(contentHtml.length).toBeGreaterThan(0);
+      expect(contentHtml).not.toContain('�');
+    });
+
+    test('getContent: parses all fields from known id without garbled text', () => {
+      expect(fixedContent.title.length).toBeGreaterThan(0);
+      expect(fixedContent.title).not.toContain('�');
+      expect(fixedContent.proposalReason).not.toBeNull();
+      expect(fixedContent.proposalReason?.length ?? 0).toBeGreaterThan(0);
+      expect(fixedContent.proposalReason ?? '').not.toContain('�');
+      expect(fixedContent.billNumber).not.toBeNull();
+      expect(fixedContent.proposer).not.toBeNull();
+      expect(fixedContent.proposalDate).not.toBeNull();
+      expect(fixedContent.committee).not.toBeNull();
+      expect(fixedContent.referralDate).not.toBeNull();
+      expect(fixedContent.noticePeriod).not.toBeNull();
+      expect(fixedContent.proposalSession).not.toBeNull();
+    });
+
+    test('getContentHTML: throws when id is an empty string', async () => {
+      await expect(palCrawl.getContentHTML('')).rejects.toThrow(
+        'id is required',
+      );
+    });
+
+    test('getContentHTML: throws when id is whitespace only', async () => {
+      await expect(palCrawl.getContentHTML('   ')).rejects.toThrow(
+        'id is required',
+      );
+    });
   });
-  test('constructor: should use all custom config options', () => {
-    const config: PalCrawlConfig = {
-      userAgent: 'Custom Agent',
-      timeout: 15000,
-      retryCount: 2,
-      customHeaders: {
-        Accept: 'application/json',
-      },
-    };
-    const palCrawl = new PalCrawl(config);
-    expect(palCrawl).toBeInstanceOf(PalCrawl);
+
+  // ── done legislative notices (integration) ───────────────────────────────────
+
+  describe('done legislative notices', () => {
+    let doneHtml = '';
+    let doneTable: ITableData[] = [];
+    let doneContentHtml = '';
+    let doneContent: Awaited<ReturnType<PalCrawl['getDoneContent']>>;
+
+    beforeAll(async () => {
+      [doneHtml, doneContentHtml] = await Promise.all([
+        palCrawl.getDoneHTML(),
+        palCrawl.getDoneContentHTML(FIXED_DONE_CONTENT_ID),
+      ]);
+      doneTable = palCrawl.parseTable(doneHtml);
+      doneContent = palCrawl.parseContent(doneContentHtml);
+      debugLog('doneTable', doneTable);
+      debugLog('doneContent', doneContent);
+    });
+
+    test('getDoneHTML: returns a non-garbled html string', () => {
+      expect(typeof doneHtml).toBe('string');
+      expect(doneHtml.length).toBeGreaterThan(0);
+      expect(doneHtml).not.toContain('�');
+    });
+
+    test('getDone: returns 10 items per page', async () => {
+      const result = await palCrawl.getDone();
+      expect(result).toHaveLength(10);
+    });
+
+    test('getDone: each item has valid structure and no garbled text', () => {
+      doneTable.forEach((e) => {
+        expect(e.subject).not.toContain('�');
+        expect(e.proposerCategory).not.toContain('�');
+        expect(e.committee).not.toContain('�');
+        expect(e.contentId).not.toBeNull();
+        expect(e.contentId?.startsWith('PRC_')).toBe(true);
+      });
+    });
+
+    test('getDoneContentHTML: returns non-empty html for known id', () => {
+      expect(typeof doneContentHtml).toBe('string');
+      expect(doneContentHtml.length).toBeGreaterThan(0);
+      expect(doneContentHtml).not.toContain('�');
+    });
+
+    test('getDoneContent: parses title and bill info from known id', () => {
+      expect(doneContent.title.length).toBeGreaterThan(0);
+      expect(doneContent.title).not.toContain('�');
+      expect(doneContent.billNumber).not.toBeNull();
+      expect(doneContent.proposer).not.toBeNull();
+      expect(doneContent.proposalDate).not.toBeNull();
+      expect(doneContent.committee).not.toBeNull();
+    });
+
+    test('getDoneContentHTML: throws when id is an empty string', async () => {
+      await expect(palCrawl.getDoneContentHTML('')).rejects.toThrow(
+        'id is required',
+      );
+    });
+
+    test('getDoneContentHTML: throws when id is whitespace only', async () => {
+      await expect(palCrawl.getDoneContentHTML('   ')).rejects.toThrow(
+        'id is required',
+      );
+    });
   });
 });

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -1,4 +1,9 @@
-import { ITableData, PalCrawl, type PalCrawlConfig } from './pal';
+import {
+  ITableData,
+  ISearchResult,
+  PalCrawl,
+  type PalCrawlConfig,
+} from './pal';
 import { PalParser } from './parser';
 
 const FIXED_ONGOING_CONTENT_ID = 'PRC_W2W6V0D4D0B9C1B4B4Z6V2W0U7V2T9';
@@ -118,7 +123,36 @@ const CONTENT_HTML = `
 </div>
 `;
 
-// ─── PalParser ────────────────────────────────────────────────────────────────
+const SEARCH_RESULT_HTML = `
+<div class="board_count">
+  <span>전체</span>
+  <strong>143</strong>
+  <span>건 (2/15 페이지)</span>
+</div>
+<table>
+  <tbody>
+    <tr>
+      <td>42</td>
+      <td class="td_block">
+        <a href="/napal/lgsltpa/lgsltpaOngoing/view.do?lgsltPaId=PRC_TEST000" class="board_subject">테스트 법률안 (홍길동의원 등 5인)</a>
+      </td>
+      <td>의원</td>
+      <td>법제사법위원회</td>
+      <td></td>
+      <td>
+        <a href="#">버튼</a>
+        <a href="https://example.com/file.hwp">hwp</a>
+        <a href="https://example.com/file.pdf">pdf</a>
+      </td>
+      <td></td>
+      <td>1,234</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+// ─── PalParser ──────────────────────────────────────────────────────────────────────────────
 
 describe('PalParser', () => {
   const parser = new PalParser();
@@ -248,6 +282,31 @@ describe('PalParser', () => {
           </div>
         `),
       ).not.toThrow();
+    });
+  });
+  describe('parseSearchResult', () => {
+    test('parses total, totalPages, currentPage, and items from fixture', () => {
+      const result = parser.parseSearchResult(SEARCH_RESULT_HTML);
+      expect(result.total).toBe(143);
+      expect(result.totalPages).toBe(15);
+      expect(result.currentPage).toBe(2);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].subject).toBe('테스트 법률안 (홍길동의원 등 5인)');
+    });
+
+    test('returns zero total and empty items for empty html', () => {
+      const result = parser.parseSearchResult('');
+      expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.items).toHaveLength(0);
+    });
+
+    test('falls back to items.length when count structure is absent', () => {
+      const result = parser.parseSearchResult(TABLE_ROW_HTML);
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(result.currentPage).toBe(1);
     });
   });
 });
@@ -465,6 +524,173 @@ describe('PalCrawl', () => {
       await expect(palCrawl.getDoneContentHTML('   ')).rejects.toThrow(
         'id is required',
       );
+    });
+  });
+
+  // ── search / searchDone (integration) ─────────────────────────────────────────
+
+  describe('search / searchDone', () => {
+    test('search: returns ISearchResult with total, totalPages, currentPage', async () => {
+      const result = await palCrawl.search();
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.totalPages).toBeGreaterThan(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.items.length).toBeGreaterThan(0);
+    });
+
+    test('search: billName filter returns matching items', async () => {
+      const result = await palCrawl.search({ billName: '도로교통' });
+      expect(result.items.length).toBeGreaterThan(0);
+      result.items.forEach((item) => {
+        expect(item.subject).toMatch(/도로교통/);
+      });
+    });
+
+    test('search: sortCol=BILL_NAME sortGbn=ASC returns alphabetically sorted items', async () => {
+      const result = await palCrawl.search({
+        sortCol: 'BILL_NAME',
+        sortGbn: 'ASC',
+        pageUnit: 5,
+      });
+      expect(result.items.length).toBeGreaterThan(0);
+      // First subject should start alphabetically early (가ㅠ)
+      expect(result.items[0].subject).not.toContain('오류');
+    });
+
+    test('searchDone: returns ISearchResult with large total', async () => {
+      const result = await palCrawl.searchDone();
+      expect(result.total).toBeGreaterThan(1000);
+      expect(result.totalPages).toBeGreaterThan(100);
+      expect(result.currentPage).toBe(1);
+    });
+
+    test('searchDone: fromAge/toAge filter narrows results', async () => {
+      const result = await palCrawl.searchDone({
+        fromAge: 22,
+        toAge: 22,
+        pageUnit: 5,
+      });
+      // The site always reports the global total in the count area,
+      // but the returned items are filtered to the specified session range.
+      expect(result.items.length).toBeGreaterThan(0);
+      expect(result.items.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── getPage / getDonePage (integration) ─────────────────────────────────────
+
+  describe('getPage / getDonePage', () => {
+    test('getPage(1): returns same items as get()', async () => {
+      const [page1, legacy] = await Promise.all([
+        palCrawl.getPage(1),
+        palCrawl.get(),
+      ]);
+      expect(page1).toHaveLength(legacy.length);
+      expect(page1[0].subject).toBe(legacy[0].subject);
+    });
+
+    test('getPage(2): returns different items from page 1', async () => {
+      const [page1, page2] = await Promise.all([
+        palCrawl.getPage(1),
+        palCrawl.getPage(2),
+      ]);
+      expect(page1.length).toBeGreaterThan(0);
+      expect(page2.length).toBeGreaterThan(0);
+      expect(page1[0].subject).not.toBe(page2[0].subject);
+    });
+
+    test('getPage: pageUnit=20 returns up to 20 items', async () => {
+      const items = await palCrawl.getPage(1, 20);
+      expect(items.length).toBeLessThanOrEqual(20);
+      expect(items.length).toBeGreaterThan(10);
+    });
+
+    test('getDonePage(2): returns items different from page 1', async () => {
+      const [page1, page2] = await Promise.all([
+        palCrawl.getDonePage(1),
+        palCrawl.getDonePage(2),
+      ]);
+      expect(page1[0].subject).not.toBe(page2[0].subject);
+    });
+  });
+
+  // ── getAllPages / getAllDonePages (integration) ──────────────────────────────
+
+  describe('getAllPages / getAllDonePages', () => {
+    test('getAllPages: yields exactly maxPages results', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllPages(
+        { pageUnit: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages).toHaveLength(2);
+      expect(pages[0].items.length).toBeGreaterThan(0);
+      expect(pages[1].items.length).toBeGreaterThan(0);
+    });
+
+    test('getAllPages: currentPage increments correctly', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllPages(
+        { pageUnit: 5 },
+        { maxPages: 3, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].currentPage).toBe(1);
+      expect(pages[1].currentPage).toBe(2);
+      expect(pages[2].currentPage).toBe(3);
+    });
+
+    test('getAllPages: total and totalPages are consistent across pages', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllPages(
+        {},
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].total).toBe(pages[1].total);
+      expect(pages[0].totalPages).toBe(pages[1].totalPages);
+    });
+
+    test('getAllPages: page 2 items differ from page 1', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllPages(
+        { pageUnit: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].items[0].subject).not.toBe(pages[1].items[0].subject);
+    });
+
+    test('getAllPages: concurrency > 1 yields pages in order', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllPages(
+        { pageUnit: 5 },
+        { maxPages: 4, delayMs: 0, concurrency: 2 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages).toHaveLength(4);
+      for (let i = 0; i < pages.length; i++) {
+        expect(pages[i].currentPage).toBe(i + 1);
+      }
+    });
+
+    test('getAllDonePages: yields 2 pages of done notices', async () => {
+      const pages: ISearchResult[] = [];
+      for await (const page of palCrawl.getAllDonePages(
+        { pageUnit: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages).toHaveLength(2);
+      expect(pages[0].total).toBeGreaterThan(1000);
+      expect(pages[0].items[0].subject).not.toBe(pages[1].items[0].subject);
     });
   });
 });

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -1,15 +1,51 @@
 import { URL } from 'url';
 import { Config } from './config';
 import { HttpClient } from './http-client';
-import { PalParser, type ITableData, type IContentData } from './parser';
+import {
+  PalParser,
+  type ITableData,
+  type IContentData,
+  type ISearchResult,
+} from './parser';
 
-export type { IAttachment, ITableData, IContentData } from './parser';
+export type {
+  IAttachment,
+  ITableData,
+  IContentData,
+  ISearchResult,
+} from './parser';
 
 export interface PalCrawlConfig {
   userAgent?: string;
   timeout?: number;
   retryCount?: number;
   customHeaders?: Record<string, string>;
+}
+
+export interface ISearchQuery {
+  pageIndex?: number;
+  pageUnit?: number;
+  committeeId?: string;
+  billName?: string;
+  represent?: string;
+  proposers?: string;
+  ppslRsonMnCn?: string;
+  sortCol?:
+    | 'BILL_NO'
+    | 'BILL_NAME'
+    | 'CURR_COMMITTEE'
+    | 'OPN_CNT'
+    | 'LGSLT_PA_RG_DT';
+  sortGbn?: 'DESC' | 'ASC';
+  fromAge?: number;
+  toAge?: number;
+  billNo?: string;
+}
+
+export interface IBulkOptions {
+  delayMs?: number;
+  concurrency?: number;
+  maxPages?: number;
 }
 
 export class PalCrawl {
@@ -24,6 +60,30 @@ export class PalCrawl {
       customHeaders: config?.customHeaders ?? {},
     });
     this.parser = new PalParser();
+  }
+
+  private buildListUrl(base: string, query: ISearchQuery): URL {
+    const url = new URL(base, Config.DOMAIN);
+    const entries: Array<[string, string | number | undefined]> = [
+      ['pageIndex', query.pageIndex],
+      ['pageUnit', query.pageUnit],
+      ['committeeId', query.committeeId],
+      ['billName', query.billName],
+      ['represent', query.represent],
+      ['proposers', query.proposers],
+      ['ppslRsonMnCn', query.ppslRsonMnCn],
+      ['sortCol', query.sortCol],
+      ['sortGbn', query.sortGbn],
+      ['fromAge', query.fromAge],
+      ['toAge', query.toAge],
+      ['billNo', query.billNo],
+    ];
+    for (const [key, value] of entries) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url;
   }
 
   public async getPalHTML(): Promise<string> {
@@ -89,5 +149,113 @@ export class PalCrawl {
   public async getDoneContent(id: string): Promise<IContentData> {
     const html = await this.getDoneContentHTML(id);
     return this.parser.parseContent(html);
+  }
+
+  // ── Search / Filter ──────────────────────────────────────────────────────────
+
+  /** Fetch ongoing notices with optional filters and return parsed result with metadata. */
+  public async search(query: ISearchQuery = {}): Promise<ISearchResult> {
+    const url = this.buildListUrl(Config.LIST_URL, { pageIndex: 1, ...query });
+    const html = await this.httpClient.get(url);
+    return this.parser.parseSearchResult(html);
+  }
+
+  /** Fetch done notices with optional filters and return parsed result with metadata. */
+  public async searchDone(query: ISearchQuery = {}): Promise<ISearchResult> {
+    const url = this.buildListUrl(Config.DONE_LIST_URL, {
+      pageIndex: 1,
+      ...query,
+    });
+    const html = await this.httpClient.get(url);
+    return this.parser.parseSearchResult(html);
+  }
+
+  // ── Explicit page access ─────────────────────────────────────────────────────
+
+  /** Fetch a specific page of ongoing notices. */
+  public async getPage(
+    pageIndex: number,
+    pageUnit?: number,
+  ): Promise<ITableData[]> {
+    const result = await this.search({ pageIndex, pageUnit });
+    return result.items;
+  }
+
+  /** Fetch a specific page of done notices. */
+  public async getDonePage(
+    pageIndex: number,
+    pageUnit?: number,
+  ): Promise<ITableData[]> {
+    const result = await this.searchDone({ pageIndex, pageUnit });
+    return result.items;
+  }
+
+  // ── Bulk / pagination helpers ────────────────────────────────────────────────
+
+  private async *_getAllPagesImpl(
+    searchFn: (query: ISearchQuery) => Promise<ISearchResult>,
+    query: Omit<ISearchQuery, 'pageIndex'>,
+    options: IBulkOptions,
+  ): AsyncGenerator<ISearchResult> {
+    const delayMs = options.delayMs ?? 500;
+    const concurrency = Math.max(1, options.concurrency ?? 1);
+
+    const first = await searchFn({ ...query, pageIndex: 1 });
+    yield first;
+
+    if (first.totalPages <= 1 || first.items.length === 0) return;
+
+    const maxPages = Math.min(
+      first.totalPages,
+      options.maxPages ?? first.totalPages,
+    );
+
+    for (let start = 2; start <= maxPages; start += concurrency) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+      const end = Math.min(start + concurrency - 1, maxPages);
+      const pageNums = Array.from(
+        { length: end - start + 1 },
+        (_, i) => start + i,
+      );
+      const results = await Promise.all(
+        pageNums.map((p) => searchFn({ ...query, pageIndex: p })),
+      );
+      for (const result of results) {
+        yield result;
+        if (result.items.length === 0) return;
+      }
+    }
+  }
+
+  /**
+   * Async generator that yields every page of ongoing notices.
+   * Respects `IBulkOptions` for rate-limiting and concurrency.
+   */
+  public getAllPages(
+    query?: Omit<ISearchQuery, 'pageIndex'>,
+    options?: IBulkOptions,
+  ): AsyncGenerator<ISearchResult> {
+    return this._getAllPagesImpl(
+      (q) => this.search(q),
+      query ?? {},
+      options ?? {},
+    );
+  }
+
+  /**
+   * Async generator that yields every page of done notices.
+   * Respects `IBulkOptions` for rate-limiting and concurrency.
+   */
+  public getAllDonePages(
+    query?: Omit<ISearchQuery, 'pageIndex'>,
+    options?: IBulkOptions,
+  ): AsyncGenerator<ISearchResult> {
+    return this._getAllPagesImpl(
+      (q) => this.searchDone(q),
+      query ?? {},
+      options ?? {},
+    );
   }
 }

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -1,8 +1,9 @@
 import { URL } from 'url';
-import * as cheerio from 'cheerio';
-import type { AnyNode } from 'domhandler';
 import { Config } from './config';
 import { HttpClient } from './http-client';
+import { PalParser, type ITableData, type IContentData } from './parser';
+
+export type { IAttachment, ITableData, IContentData } from './parser';
 
 export interface PalCrawlConfig {
   userAgent?: string;
@@ -11,36 +12,9 @@ export interface PalCrawlConfig {
   customHeaders?: Record<string, string>;
 }
 
-export interface IAttachment {
-  pdfFile: string | null;
-  hwpFile: string | null;
-}
-
-export interface ITableData {
-  num: number;
-  subject: string;
-  proposerCategory: string;
-  committee: string;
-  numComments: number;
-  link: string;
-  contentId: string | null;
-  attachments: IAttachment;
-}
-
-export interface IContentData {
-  title: string;
-  proposalReason: string | null;
-  billNumber: string | null;
-  proposer: string | null;
-  proposalDate: string | null;
-  committee: string | null;
-  referralDate: string | null;
-  noticePeriod: string | null;
-  proposalSession: string | null;
-}
-
 export class PalCrawl {
   private readonly httpClient: HttpClient;
+  private readonly parser: PalParser;
 
   constructor(config?: PalCrawlConfig) {
     this.httpClient = new HttpClient({
@@ -49,6 +23,7 @@ export class PalCrawl {
       retryCount: config?.retryCount ?? 3,
       customHeaders: config?.customHeaders ?? {},
     });
+    this.parser = new PalParser();
   }
 
   public async getPalHTML(): Promise<string> {
@@ -56,198 +31,17 @@ export class PalCrawl {
     return this.httpClient.get(url);
   }
 
-  private extractContentId(link: string): string | null {
-    try {
-      const url = new URL(link, Config.DOMAIN);
-      return (
-        url.searchParams.get('lgsltPaId') ?? url.searchParams.get('lgsltPaid')
-      );
-    } catch {
-      return null;
-    }
-  }
-
   public parseTable(html: string): ITableData[] {
-    const $ = cheerio.load(html);
-    const body = $('body');
-    const table = body.find('table > tbody > tr');
-    const output: ITableData[] = [];
-    table.map((_i, el) => {
-      const subject = $(el).find('td.td_block > a.board_subject').text().trim();
-      if (subject) {
-        const link = $(el).find('td.td_block > a.board_subject').attr('href');
-        const numComments = Number(
-          $(el).find('td:nth-child(8)').text().replace(',', '').trim(),
-        );
-        const proposerCategory = $(el).find('td:nth-child(3)').text().trim();
-        const committee = $(el).find('td:nth-child(4)').text().trim();
-        const num = Number($(el).find('td:nth-child(1)').text().trim());
-        let boardLink = '';
-        if (link) {
-          boardLink = Config.DOMAIN + link;
-        }
-        const pdfFile =
-          $(el).find('td:nth-child(6) > a:nth-child(3)').attr('href') ?? null;
-        const hwpFile =
-          $(el).find('td:nth-child(6) > a:nth-child(2)').attr('href') ?? null;
-        const attachments: IAttachment = {
-          pdfFile,
-          hwpFile,
-        };
-        const contentId = boardLink ? this.extractContentId(boardLink) : null;
-        output.push({
-          num,
-          subject,
-          proposerCategory,
-          committee,
-          numComments,
-          link: boardLink,
-          contentId,
-          attachments,
-        });
-      }
-    });
-    return output;
-  }
-
-  private normalizeText(text: string): string {
-    return text
-      .replace(/\u00a0/g, ' ')
-      .replace(/\r/g, '')
-      .split('\n')
-      .map((line) => line.replace(/\s+/g, ' ').trim())
-      .filter(Boolean)
-      .join('\n');
-  }
-
-  private extractTableCellText(
-    $: cheerio.CheerioAPI,
-    cell: cheerio.Cheerio<AnyNode>,
-  ): string {
-    const clonedCell = cell.clone();
-    clonedCell.find('.m_subject, script, style').remove();
-    clonedCell.find('a.btn_sm').remove();
-    return this.normalizeText($(clonedCell).text());
-  }
-
-  private parseBillInfoTable(
-    $: cheerio.CheerioAPI,
-  ): Pick<
-    IContentData,
-    | 'billNumber'
-    | 'proposer'
-    | 'proposalDate'
-    | 'committee'
-    | 'referralDate'
-    | 'noticePeriod'
-    | 'proposalSession'
-  > {
-    const table = $('.board-added table').first();
-    const row = table.find('tbody > tr').first();
-
-    if (!table.length || !row.length) {
-      return {
-        billNumber: null,
-        proposer: null,
-        proposalDate: null,
-        committee: null,
-        referralDate: null,
-        noticePeriod: null,
-        proposalSession: null,
-      };
-    }
-
-    const headers = table
-      .find('thead th')
-      .map((_, th) => this.normalizeText($(th).text()).replace(/\s+/g, ''))
-      .get();
-
-    const values = row
-      .children('td')
-      .map((_, td) => this.extractTableCellText($, $(td)))
-      .get();
-
-    const valueByHeader = new Map<string, string>();
-    headers.forEach((header, index) => {
-      const value = values[index];
-      if (value) {
-        valueByHeader.set(header, value);
-      }
-    });
-
-    return {
-      billNumber: valueByHeader.get('의안번호') ?? null,
-      proposer: valueByHeader.get('제안자') ?? null,
-      proposalDate: valueByHeader.get('제안일') ?? null,
-      committee: valueByHeader.get('소관위원회') ?? null,
-      referralDate: valueByHeader.get('회부일') ?? null,
-      noticePeriod: valueByHeader.get('입법예고기간') ?? null,
-      proposalSession: valueByHeader.get('제안회기') ?? null,
-    };
+    return this.parser.parseTable(html);
   }
 
   public parseContent(html: string): IContentData {
-    const $ = cheerio.load(html);
-
-    const title = this.normalizeText(
-      $('.legislation-heading h3').first().text() || $('h3').first().text(),
-    );
-
-    const sections: Record<string, string> = {};
-
-    $('.card-wrap .item').each((_, item) => {
-      const heading = this.normalizeText($(item).find('h4').first().text());
-      if (!heading) {
-        return;
-      }
-
-      const descText = this.normalizeText($(item).find('.desc').first().text());
-      if (!descText) {
-        sections[heading] = '';
-        return;
-      }
-
-      const normalizedHeading = heading.replace(/\s+/g, '');
-      const lines = descText.split('\n').filter(Boolean);
-      const firstLine = lines[0]?.replace(/\s+/g, '') ?? '';
-
-      // The first line sometimes repeats the section heading itself.
-      const content =
-        firstLine === normalizedHeading
-          ? this.normalizeText(lines.slice(1).join('\n'))
-          : descText;
-
-      sections[heading] = content;
-    });
-
-    const proposalReasonRaw =
-      Object.entries(sections).find(([heading]) =>
-        heading.replace(/\s+/g, '').includes('제안이유및주요내용'),
-      )?.[1] ?? null;
-
-    const proposalReason = proposalReasonRaw
-      ? this.normalizeText(proposalReasonRaw)
-      : null;
-
-    const billInfo = this.parseBillInfoTable($);
-
-    return {
-      title,
-      proposalReason,
-      billNumber: billInfo.billNumber,
-      proposer: billInfo.proposer,
-      proposalDate: billInfo.proposalDate,
-      committee: billInfo.committee,
-      referralDate: billInfo.referralDate,
-      noticePeriod: billInfo.noticePeriod,
-      proposalSession: billInfo.proposalSession,
-    };
+    return this.parser.parseContent(html);
   }
 
   public async get(): Promise<ITableData[]> {
     const html = await this.getPalHTML();
-    const table = this.parseTable(html);
-    return table;
+    return this.parser.parseTable(html);
   }
 
   public async getContentHTML(id: string): Promise<string> {
@@ -266,6 +60,34 @@ export class PalCrawl {
 
   public async getContent(id: string): Promise<IContentData> {
     const html = await this.getContentHTML(id);
-    return this.parseContent(html);
+    return this.parser.parseContent(html);
+  }
+
+  public async getDoneHTML(): Promise<string> {
+    const url = new URL(Config.DONE_LIST_URL, Config.DOMAIN);
+    return this.httpClient.get(url);
+  }
+
+  public async getDone(): Promise<ITableData[]> {
+    const html = await this.getDoneHTML();
+    return this.parser.parseTable(html);
+  }
+
+  public async getDoneContentHTML(id: string): Promise<string> {
+    const normalizedId = id.trim();
+    if (!normalizedId) {
+      throw new Error('id is required');
+    }
+
+    const url = new URL(Config.DONE_CONTENT_URL, Config.DOMAIN);
+    url.searchParams.set('lgsltPaid', normalizedId);
+    url.searchParams.set('lgsltPaId', normalizedId);
+
+    return this.httpClient.get(url);
+  }
+
+  public async getDoneContent(id: string): Promise<IContentData> {
+    const html = await this.getDoneContentHTML(id);
+    return this.parser.parseContent(html);
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,6 +31,13 @@ export interface IContentData {
   proposalSession: string | null;
 }
 
+export interface ISearchResult {
+  total: number;
+  totalPages: number;
+  currentPage: number;
+  items: ITableData[];
+}
+
 export class PalParser {
   private extractContentId(link: string): string | null {
     try {
@@ -84,6 +91,37 @@ export class PalParser {
       }
     });
     return output;
+  }
+
+  public parseSearchResult(html: string): ISearchResult {
+    const $ = cheerio.load(html);
+    const items = this.parseTable(html);
+
+    let total = 0;
+    let currentPage = 1;
+    let totalPages = 0;
+
+    $('span').each((_, el) => {
+      const text = $(el).text();
+      const m = text.match(/건 \((\d+)\/(\d+)\s*페이지\)/);
+      if (m) {
+        currentPage = parseInt(m[1], 10);
+        totalPages = parseInt(m[2], 10);
+        const strong = $(el).prevAll('strong').first();
+        if (strong.length) {
+          total = parseInt(strong.text().replace(/,/g, ''), 10);
+        }
+        return false; // break
+      }
+    });
+
+    // Fallback: if the page count structure is absent but items were found
+    if (totalPages === 0 && items.length > 0) {
+      totalPages = 1;
+      total = items.length;
+    }
+
+    return { total, totalPages, currentPage, items };
   }
 
   private normalizeText(text: string): string {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,222 @@
+import { URL } from 'url';
+import * as cheerio from 'cheerio';
+import type { AnyNode } from 'domhandler';
+import { Config } from './config';
+
+export interface IAttachment {
+  pdfFile: string | null;
+  hwpFile: string | null;
+}
+
+export interface ITableData {
+  num: number;
+  subject: string;
+  proposerCategory: string;
+  committee: string;
+  numComments: number;
+  link: string;
+  contentId: string | null;
+  attachments: IAttachment;
+}
+
+export interface IContentData {
+  title: string;
+  proposalReason: string | null;
+  billNumber: string | null;
+  proposer: string | null;
+  proposalDate: string | null;
+  committee: string | null;
+  referralDate: string | null;
+  noticePeriod: string | null;
+  proposalSession: string | null;
+}
+
+export class PalParser {
+  private extractContentId(link: string): string | null {
+    try {
+      const url = new URL(link, Config.DOMAIN);
+      return (
+        url.searchParams.get('lgsltPaId') ?? url.searchParams.get('lgsltPaid')
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  public parseTable(html: string): ITableData[] {
+    const $ = cheerio.load(html);
+    const body = $('body');
+    const table = body.find('table > tbody > tr');
+    const output: ITableData[] = [];
+    table.map((_i, el) => {
+      const subject = $(el).find('td.td_block > a.board_subject').text().trim();
+      if (subject) {
+        const link = $(el).find('td.td_block > a.board_subject').attr('href');
+        const numComments = Number(
+          $(el).find('td:nth-child(8)').text().replace(',', '').trim(),
+        );
+        const proposerCategory = $(el).find('td:nth-child(3)').text().trim();
+        const committee = $(el).find('td:nth-child(4)').text().trim();
+        const num = Number($(el).find('td:nth-child(1)').text().trim());
+        let boardLink = '';
+        if (link) {
+          boardLink = Config.DOMAIN + link;
+        }
+        const pdfFile =
+          $(el).find('td:nth-child(6) > a:nth-child(3)').attr('href') ?? null;
+        const hwpFile =
+          $(el).find('td:nth-child(6) > a:nth-child(2)').attr('href') ?? null;
+        const attachments: IAttachment = {
+          pdfFile,
+          hwpFile,
+        };
+        const contentId = boardLink ? this.extractContentId(boardLink) : null;
+        output.push({
+          num,
+          subject,
+          proposerCategory,
+          committee,
+          numComments,
+          link: boardLink,
+          contentId,
+          attachments,
+        });
+      }
+    });
+    return output;
+  }
+
+  private normalizeText(text: string): string {
+    return text
+      .replace(/\u00a0/g, ' ')
+      .replace(/\r/g, '')
+      .split('\n')
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private extractTableCellText(
+    $: cheerio.CheerioAPI,
+    cell: cheerio.Cheerio<AnyNode>,
+  ): string {
+    const clonedCell = cell.clone();
+    clonedCell.find('.m_subject, script, style').remove();
+    clonedCell.find('a.btn_sm').remove();
+    return this.normalizeText($(clonedCell).text());
+  }
+
+  private parseBillInfoTable(
+    $: cheerio.CheerioAPI,
+  ): Pick<
+    IContentData,
+    | 'billNumber'
+    | 'proposer'
+    | 'proposalDate'
+    | 'committee'
+    | 'referralDate'
+    | 'noticePeriod'
+    | 'proposalSession'
+  > {
+    const table = $('.board-added table').first();
+    const row = table.find('tbody > tr').first();
+
+    if (!table.length || !row.length) {
+      return {
+        billNumber: null,
+        proposer: null,
+        proposalDate: null,
+        committee: null,
+        referralDate: null,
+        noticePeriod: null,
+        proposalSession: null,
+      };
+    }
+
+    const headers = table
+      .find('thead th')
+      .map((_, th) => this.normalizeText($(th).text()).replace(/\s+/g, ''))
+      .get();
+
+    const values = row
+      .children('td')
+      .map((_, td) => this.extractTableCellText($, $(td)))
+      .get();
+
+    const valueByHeader = new Map<string, string>();
+    headers.forEach((header, index) => {
+      const value = values[index];
+      if (value) {
+        valueByHeader.set(header, value);
+      }
+    });
+
+    return {
+      billNumber: valueByHeader.get('의안번호') ?? null,
+      proposer: valueByHeader.get('제안자') ?? null,
+      proposalDate: valueByHeader.get('제안일') ?? null,
+      committee: valueByHeader.get('소관위원회') ?? null,
+      referralDate: valueByHeader.get('회부일') ?? null,
+      noticePeriod: valueByHeader.get('입법예고기간') ?? null,
+      proposalSession: valueByHeader.get('제안회기') ?? null,
+    };
+  }
+
+  public parseContent(html: string): IContentData {
+    const $ = cheerio.load(html);
+
+    const title = this.normalizeText(
+      $('.legislation-heading h3').first().text() || $('h3').first().text(),
+    );
+
+    const sections: Record<string, string> = {};
+
+    $('.card-wrap .item').each((_, item) => {
+      const heading = this.normalizeText($(item).find('h4').first().text());
+      if (!heading) {
+        return;
+      }
+
+      const descText = this.normalizeText($(item).find('.desc').first().text());
+      if (!descText) {
+        sections[heading] = '';
+        return;
+      }
+
+      const normalizedHeading = heading.replace(/\s+/g, '');
+      const lines = descText.split('\n').filter(Boolean);
+      const firstLine = lines[0]?.replace(/\s+/g, '') ?? '';
+
+      // The first line sometimes repeats the section heading itself.
+      const content =
+        firstLine === normalizedHeading
+          ? this.normalizeText(lines.slice(1).join('\n'))
+          : descText;
+
+      sections[heading] = content;
+    });
+
+    const proposalReasonRaw =
+      Object.entries(sections).find(([heading]) =>
+        heading.replace(/\s+/g, '').includes('제안이유및주요내용'),
+      )?.[1] ?? null;
+
+    const proposalReason = proposalReasonRaw
+      ? this.normalizeText(proposalReasonRaw)
+      : null;
+
+    const billInfo = this.parseBillInfoTable($);
+
+    return {
+      title,
+      proposalReason,
+      billNumber: billInfo.billNumber,
+      proposer: billInfo.proposer,
+      proposalDate: billInfo.proposalDate,
+      committee: billInfo.committee,
+      referralDate: billInfo.referralDate,
+      noticePeriod: billInfo.noticePeriod,
+      proposalSession: billInfo.proposalSession,
+    };
+  }
+}


### PR DESCRIPTION
This pull request significantly expands the functionality of the `pal-crawl` package, adding support for "종료된 입법예고" (done legislative notices), advanced search and pagination, and bulk data collection. It also refactors the codebase for better modularity and maintainability, and updates the documentation to reflect these enhancements.

The most important changes are:

**New Features: Done Notices, Search, and Bulk Collection**
- Added support for fetching "done" legislative notices, including new methods: `getDone`, `getDoneContentHTML`, `getDoneContent`, `searchDone`, `getDonePage`, and `getAllDonePages` in the `PalCrawl` class. These mirror the existing methods for ongoing notices but target completed ones. [[1]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129L2-R16) [[2]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129R62-R259) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R5-R6)
- Introduced advanced search and pagination capabilities via `search`, `searchDone`, `getPage`, and `getDonePage` methods, allowing filtering and retrieval of specific pages of notices.
- Implemented bulk collection through async generators `getAllPages` and `getAllDonePages`, with options for rate-limiting and concurrency, enabling efficient large-scale data gathering.

**API and Type Enhancements**
- Added new TypeScript interfaces: `ISearchQuery`, `ISearchResult`, and `IBulkOptions` to describe search filters, paginated results, and bulk collection options. These are exported for external use. [[1]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129L14-R53) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R6-R11)
- Updated the `Config` enum to include URLs for done notices.

**Internal Refactoring**
- Refactored parsing logic by delegating table and content parsing to the new `PalParser` class, improving modularity and separation of concerns. [[1]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129L2-R16) [[2]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129R62-R259)
- Removed redundant and duplicated parsing code from `pal.ts` in favor of using `PalParser`.

**Documentation Updates**
- Extensively updated `README.md` to document all new methods, interfaces, usage examples for done notices, search, and bulk collection, and clarified method signatures. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R128-R178) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R195) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234-R398) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R463-R534)

These changes provide users with much more flexible and powerful ways to access and process both ongoing and completed legislative notices, while making the codebase easier to maintain and extend.