### PR TITLE
feat: implement support for crawling and parsing legislative bills from National Legislation Center (NsmLmSts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [getDetail](#getdetailbillno-string--promiseinsmBilldetail)
   - [getAllPages (NsmLmSts)](#getallpagesquery-options--asyncgeneratorinsmsearchresult)
   - [getAllPendingPages](#getallpendingpagesquery-options--asyncgeneratorinsmsearchresult)
+  - [Screenshot (NsmLmSts)](#getnsmlisscreenshotquery--promisebuffer)
 - [Examples](#examples)
 - [License](#license)
 
@@ -729,6 +730,36 @@ for await (const page of nsm.getAllPendingPages({}, { delayMs: 500 })) {
   );
 }
 ```
+
+---
+
+### getNsmListScreenshot(query?) => Promise\<Buffer>
+
+국회입법현황 목록 페이지의 스크린샷을 `Buffer`로 반환합니다. `screenshot.enabled: true`로 초기화해야 합니다.
+
+### getDetailScreenshot(billNo: string) => Promise\<Buffer>
+
+법안 상세 페이지의 스크린샷을 `Buffer`로 반환합니다.
+
+```typescript
+import fs from 'node:fs';
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts({ screenshot: { enabled: true, fullPage: true } });
+
+try {
+  const items = await nsm.getPage(1);
+  const listBuf = await nsm.getNsmListScreenshot();
+  fs.writeFileSync('nsm-list.png', listBuf);
+
+  const detailBuf = await nsm.getDetailScreenshot(items[0].billNo);
+  fs.writeFileSync('nsm-detail.png', detailBuf);
+} finally {
+  await nsm.closeBrowser();
+}
+```
+
+> `takeScreenshot(url)`, `initBrowser()`, `closeBrowser()`, `updateScreenshotConfig()` 메서드는 `PalCrawl`과 공유되는 `ScreenshotBase`에서 상속됩니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@
   - [search / searchDone](#searchquery-isearchquery--promiseisearchresult)
   - [getPage / getDonePage](#getpagepageindex-number-pageunit-number--promiseitable-data)
   - [getAllPages / getAllDonePages](#getallpagesquery-isearchquery-options-ibulkoptions--asyncgeneratorisearchresult)
+- [NsmLmSts - 국민참여입법센터 국회입법현황](#nsmlmsts--국민참여입법센터-국회입법현황)
+  - [NsmLmSts Configuration](#nsmlmsts-configuration)
+  - [NsmLmSts Types](#nsmlmsts-types)
+  - [search (NsmLmSts)](#searchquery-insmsearchquery--promiseinsmsearchresult)
+  - [searchPending](#searchpendingquery--promiseinsmsearchresult)
+  - [getPage (NsmLmSts)](#getpagepageindex-number-query--promiseinsmBillitem)
+  - [getDetail](#getdetailbillno-string--promiseinsmBilldetail)
+  - [getAllPages (NsmLmSts)](#getallpagesquery-options--asyncgeneratorinsmsearchresult)
+  - [getAllPendingPages](#getallpendingpagesquery-options--asyncgeneratorinsmsearchresult)
 - [Examples](#examples)
 - [License](#license)
 
@@ -38,6 +47,8 @@
 ## Introduction
 
 국회입법예고(pal.assembly.go.kr) 사이트에서 진행 중인 입법 예고 데이터를 크롤링하는 도구입니다. 입법 예고의 주요 정보를 손쉽게 가져올 수 있습니다.
+
+국민참여입법센터 국회입법현황(opinion.lawmaking.go.kr)에서 법안을 크롤링하는 `NsmLmSts` 클래스도 포함되어 있습니다. 위원회 회부 이전에 발의된 상태로 대기 중인 법안까지 조회할 수 있습니다.
 
 ---
 
@@ -463,6 +474,264 @@ for await (const page of palCrawl.getAllDonePages(
 
 ---
 
+## NsmLmSts - 국민참여입법센터 국회입법현황
+
+`NsmLmSts` 클래스는 [국민참여입법센터 국회입법현황](https://opinion.lawmaking.go.kr/gcom/nsmLmSts/out)에서 법안 목록과 상세 정보를 크롤링합니다. 위원회 회부 이전 발의 상태 법안까지 필터링할 수 있는 것이 특징입니다.
+
+---
+
+### NsmLmSts Configuration
+
+`NsmLmSts` 생성자는 `PalCrawl`과 동일한 네트워크 설정 옵션을 받습니다 (스크린샷 제외).
+
+```typescript
+const nsm = new NsmLmSts({
+  userAgent: 'My Bot 1.0',
+  timeout: 15000,
+  retryCount: 3,
+  customHeaders: { 'Accept-Language': 'ko-KR' },
+});
+```
+
+---
+
+### NsmLmSts Types
+
+`INsmSearchQuery`는 목록 검색 필터 옵션입니다.
+
+```typescript
+interface INsmSearchQuery {
+  pageIndex?: number; // 페이지 번호 (기본값: 1)
+  pageSize?: number; // 페이지당 건수 (10 | 20 | 50 | 100)
+  sugCd?: string; // 제안대수 시작 (예: "22" → 제22대)
+  endSugCd?: string; // 제안대수 끝
+  sgtCls?: NsmProposerType; // 발의구분
+  cptOfiOrgCd?: string; // 소관부처 코드
+  rslRsltNmL?: NsmProgressStatus; // 국회현황 코드
+  rslRsltNmR?: NsmResolutionStatus; // 의결현황 코드
+  scCptPpostCmt?: string; // 상임위 (예: "법제사법위원회")
+  searchStDtNew?: string; // 제안일자 시작 (YYYY-MM-DD)
+  searchEdDtNew?: string; // 제안일자 종료 (YYYY-MM-DD)
+  scPpsUsr?: string; // 제안자
+  issLawitmYn?: 'Y'; // 규제 신설·강화 해당 법안만
+  stDt?: string; // 추진일자 시작 (YYYY-MM-DD)
+  edDt?: string; // 추진일자 종료 (YYYY-MM-DD)
+  scBlNmSct?: string; // 의안번호 또는 의안명
+  sortCol?: string;
+  sortOrder?: 'DESC' | 'ASC';
+}
+```
+
+`NsmProgressStatus`는 국회현황 필터 코드입니다.
+
+| 코드       | 의미                                   |
+| ---------- | -------------------------------------- |
+| `'900101'` | 발의 (위원회 회부 이전 대기 상태 포함) |
+| `'900102'` | 위원회 회부                            |
+| `'900103'` | 위원회 상정                            |
+| `'900104'` | 위원회 법안소위                        |
+| `'900105'` | 위원회 전체회의                        |
+| `'900106'` | 법사위 심사                            |
+| `'900107'` | 본회의 심의                            |
+| `'900108'` | 정부이송                               |
+| `'900109'` | 공포                                   |
+
+`NsmProposerType`은 발의구분 코드입니다.
+
+| 코드       | 의미   |
+| ---------- | ------ |
+| `'900201'` | 정부   |
+| `'900202'` | 의원   |
+| `'900203'` | 위원장 |
+
+`NsmResolutionStatus`는 의결현황 코드입니다.
+
+| 코드       | 의미         |
+| ---------- | ------------ |
+| `'902911'` | 수정가결     |
+| `'902912'` | 원안가결     |
+| `'902913'` | 부결         |
+| `'902914'` | 대안반영폐기 |
+| `'902915'` | 폐기         |
+| `'902916'` | 임기만료폐기 |
+| `'902917'` | 철회         |
+
+`INsmBillItem`은 목록 페이지의 법안 한 건입니다.
+
+```typescript
+interface INsmBillItem {
+  billName: string; // 법안명
+  billNo: string; // 의안번호
+  link: string; // 상세 페이지 링크
+  proposer: string; // 제안자
+  proposalDate: string; // 제안일
+  committee: string; // 상임위원회 (회부 전이면 빈 문자열)
+  ministry: string; // 소관부처
+  progressStatus: string; // 국회현황 (예: "발의", "위원회 회부")
+  progressDate: string; // 추진일자
+  resolutionStatus: string; // 의결현황 (예: "원안가결")
+  resolutionDate: string; // 의결일자
+}
+```
+
+`INsmBillDetail`은 상세 페이지의 법안 정보입니다.
+
+```typescript
+interface INsmBillDetail {
+  title: string; // 법안명
+  billNo: string; // 의안번호
+  proposalInfo: string; // 발의정보 원문 텍스트
+  proposer: string; // 제안자
+  proposalDate: string; // 제안일
+  session: string; // 제안회기 (예: "제435회 국회(임시회)")
+  proposalReason: string | null; // 제안이유 및 주요내용
+  attachments: INsmAttachment[]; // 의안원문 첨부파일 목록
+}
+```
+
+`INsmAttachment`는 첨부파일 정보입니다.
+
+```typescript
+interface INsmAttachment {
+  filename: string; // 파일명
+  fileId: string; // fnDownload() 호출에 사용되는 파일 ID
+}
+```
+
+`INsmSearchResult`는 목록 검색 결과입니다.
+
+```typescript
+interface INsmSearchResult {
+  total: number;
+  totalPages: number;
+  currentPage: number;
+  items: INsmBillItem[];
+}
+```
+
+---
+
+### search(query?: INsmSearchQuery) => Promise\<INsmSearchResult>
+
+법안 목록을 검색합니다. 필터를 지정하지 않으면 최신 법안 1페이지를 반환합니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+
+// 기본 조회
+const result = await nsm.search();
+console.log(result.total, result.items);
+
+// 제22대 의원발의 법안 조회
+const filtered = await nsm.search({
+  sugCd: '22',
+  endSugCd: '22',
+  sgtCls: '900202',
+  pageSize: 20,
+});
+```
+
+---
+
+### searchPending(query?) => Promise\<INsmSearchResult>
+
+위원회 회부 이전 발의 상태(`rslRsltNmL: '900101'`)로 고정하여 조회합니다. 대기 중인 법안만 가져오고 싶을 때 사용합니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+
+// 현재 발의 상태로 대기 중인 법안 조회
+const pending = await nsm.searchPending();
+console.log(`발의 대기 중: ${pending.total}건`);
+pending.items.forEach((item) => console.log(item.billName));
+```
+
+---
+
+### getPage(pageIndex: number, query?) => Promise\<INsmBillItem[]>
+
+특정 페이지의 법안 목록만 배열로 반환합니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+const page2 = await nsm.getPage(2, { pageSize: 20 });
+```
+
+---
+
+### getDetailHTML(billNo: string) => Promise\<string>
+
+법안 상세 페이지의 HTML 원문을 반환합니다.
+
+### getDetail(billNo: string) => Promise\<INsmBillDetail>
+
+의안번호로 법안 상세 정보를 조회합니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+const items = await nsm.getPage(1);
+const detail = await nsm.getDetail(items[0].billNo);
+
+console.log(detail.title);
+console.log(detail.proposer);
+console.log(detail.proposalDate);
+console.log(detail.session);
+console.log(detail.proposalReason);
+console.log(detail.attachments);
+// [{ filename: '법안.hwp', fileId: '99001' }, ...]
+```
+
+---
+
+### getAllPages(query?, options?) => AsyncGenerator\<INsmSearchResult>
+
+전체 페이지를 순차적으로 yield하는 async generator입니다. `IBulkOptions`로 딜레이·동시성·최대 페이지를 조절할 수 있습니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+
+for await (const page of nsm.getAllPages(
+  { pageSize: 20 },
+  { maxPages: 5, delayMs: 300 },
+)) {
+  console.log(
+    `페이지 ${page.currentPage}/${page.totalPages}: ${page.items.length}건`,
+  );
+}
+```
+
+---
+
+### getAllPendingPages(query?, options?) => AsyncGenerator\<INsmSearchResult>
+
+발의 상태(`rslRsltNmL: '900101'`) 법안 전체를 페이지 단위로 yield합니다.
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+const pendingItems = [];
+
+for await (const page of nsm.getAllPendingPages({}, { delayMs: 500 })) {
+  pendingItems.push(...page.items);
+  console.log(
+    `${page.currentPage}/${page.totalPages}: 누적 ${pendingItems.length}건`,
+  );
+}
+```
+
+---
+
 ## Examples
 
 ### 기본 사용법
@@ -627,6 +896,67 @@ try {
 ```
 
 `takeScreenshot`, `getPalScreenshot`, `getContentScreenshot`, `getDoneScreenshot`, `getDoneContentScreenshot`는 모두 `Buffer`를 반환합니다.
+
+### 국민참여입법센터에서 발의 대기 중인 법안 전체 수집
+
+```typescript
+import { NsmLmSts, type INsmBillItem } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+const pendingItems: INsmBillItem[] = [];
+
+for await (const page of nsm.getAllPendingPages({}, { delayMs: 500 })) {
+  pendingItems.push(...page.items);
+  console.log(
+    `수집 중: ${page.currentPage}/${page.totalPages} 페이지 (누적 ${pendingItems.length}건)`,
+  );
+}
+
+console.log(`발의 대기 중 법안 ${pendingItems.length}건 수집 완료`);
+```
+
+### 국민참여입법센터에서 법안 상세 정보 조회
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+
+// 1페이지 목록에서 첫 번째 법안 상세 조회
+const items = await nsm.getPage(1);
+if (items.length > 0) {
+  const detail = await nsm.getDetail(items[0].billNo);
+  console.log(detail.title);
+  console.log(detail.proposer);
+  console.log(detail.proposalDate);
+  console.log(detail.session);
+  console.log(detail.proposalReason);
+  // 첨부파일 목록
+  detail.attachments.forEach((att) => {
+    console.log(`${att.filename} (ID: ${att.fileId})`);
+  });
+}
+```
+
+### 국민참여입법센터 조건부 검색 (제22대 의원발의 법안)
+
+```typescript
+import { NsmLmSts } from 'pal-crawl';
+
+const nsm = new NsmLmSts();
+
+const result = await nsm.search({
+  sugCd: '22',
+  endSugCd: '22',
+  sgtCls: '900202', // 의원발의
+  pageSize: 50,
+});
+
+console.log(`제22대 의원발의 법안: ${result.total}건`);
+result.items.forEach((item) => {
+  console.log(`[${item.progressStatus}] ${item.billName} (${item.proposer})`);
+});
+```
 
 ### 에러 처리
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pal-crawl",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pal-crawl",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pal-crawl",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "국회입법예고(pal.assembly.go.kr)의 진행 중인 입법 예고 크롤러",
   "license": "MIT",
   "author": "vientorepublic",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,4 +5,7 @@ export enum Config {
   DONE_LIST_URL = '/napal/lgsltpa/lgsltpaDone/list.do',
   DONE_CONTENT_URL = '/napal/lgsltpa/lgsltpaDone/view.do',
   UserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  // 국민참여입법센터 국회입법현황 (opinion.lawmaking.go.kr)
+  NSM_DOMAIN = 'https://opinion.lawmaking.go.kr',
+  NSM_LIST_URL = '/gcom/nsmLmSts/out',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
   PalCrawl,
+  NsmLmSts,
   type ITableData,
   type IAttachment,
   type IContentData,
@@ -8,6 +9,14 @@ export {
   type IBulkOptions,
   type PalCrawlConfig,
   type ScreenshotOptions,
+  type INsmSearchQuery,
+  type INsmSearchResult,
+  type INsmBillItem,
+  type INsmBillDetail,
+  type INsmAttachment,
+  type NsmProgressStatus,
+  type NsmProposerType,
+  type NsmResolutionStatus,
 } from './pal';
-export { PalParser } from './parser';
+export { PalParser, NsmLmStsParser } from './parser';
 export { Config } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  ScreenshotBase,
   PalCrawl,
   NsmLmSts,
   type ITableData,

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -257,7 +257,7 @@ const NSM_DETAIL_HTML = `
 </table>
 `;
 
-/** 상세 페이지 — 제안이유 없음 (pre 태그 없는 경우) */
+/** 상세 페이지 - 제안이유 없음 (pre 태그 없는 경우) */
 const NSM_DETAIL_HTML_NO_REASON = `
 <h2>최소 법률안</h2>
 <table>
@@ -332,7 +332,7 @@ describe('PalParser', () => {
 
     test('strips the repeated heading line from proposal reason', () => {
       const content = parser.parseContent(CONTENT_HTML);
-      // The desc starts with "제안이유 및 주요내용" which matches the heading — it must be stripped.
+      // The desc starts with "제안이유 및 주요내용" which matches the heading - it must be stripped.
       expect(content.proposalReason).not.toMatch(/제안이유/);
     });
 

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -530,9 +530,10 @@ describe('PalCrawl', () => {
       expect(listHtml).not.toContain('�');
     });
 
-    test('get: returns 10 items per page', async () => {
+    test('get: returns items (up to 10 per page)', async () => {
       const result = await palCrawl.get();
-      expect(result).toHaveLength(10);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(10);
     });
 
     test('get: each item has valid structure and no garbled text', () => {
@@ -711,18 +712,18 @@ describe('PalCrawl', () => {
       expect(page1[0].subject).toBe(legacy[0].subject);
     });
 
-    test('getPage(2): returns different items from page 1', async () => {
+    test('getDonePage(2): returns different items from page 1', async () => {
       const [page1, page2] = await Promise.all([
-        palCrawl.getPage(1),
-        palCrawl.getPage(2),
+        palCrawl.getDonePage(1),
+        palCrawl.getDonePage(2),
       ]);
       expect(page1.length).toBeGreaterThan(0);
       expect(page2.length).toBeGreaterThan(0);
       expect(page1[0].subject).not.toBe(page2[0].subject);
     });
 
-    test('getPage: pageUnit=20 returns up to 20 items', async () => {
-      const items = await palCrawl.getPage(1, 20);
+    test('getDonePage: pageUnit=20 returns up to 20 items', async () => {
+      const items = await palCrawl.getDonePage(1, 20);
       expect(items.length).toBeLessThanOrEqual(20);
       expect(items.length).toBeGreaterThan(10);
     });
@@ -752,9 +753,9 @@ describe('PalCrawl', () => {
       expect(pages[1].items.length).toBeGreaterThan(0);
     });
 
-    test('getAllPages: currentPage increments correctly', async () => {
+    test('getAllDonePages: currentPage increments correctly', async () => {
       const pages: ISearchResult[] = [];
-      for await (const page of palCrawl.getAllPages(
+      for await (const page of palCrawl.getAllDonePages(
         { pageUnit: 5 },
         { maxPages: 3, delayMs: 0 },
       )) {
@@ -765,9 +766,9 @@ describe('PalCrawl', () => {
       expect(pages[2].currentPage).toBe(3);
     });
 
-    test('getAllPages: total and totalPages are consistent across pages', async () => {
+    test('getAllDonePages: total and totalPages are consistent across pages', async () => {
       const pages: ISearchResult[] = [];
-      for await (const page of palCrawl.getAllPages(
+      for await (const page of palCrawl.getAllDonePages(
         {},
         { maxPages: 2, delayMs: 0 },
       )) {
@@ -788,9 +789,9 @@ describe('PalCrawl', () => {
       expect(pages[0].items[0].subject).not.toBe(pages[1].items[0].subject);
     });
 
-    test('getAllPages: concurrency > 1 yields pages in order', async () => {
+    test('getAllDonePages: concurrency > 1 yields pages in order', async () => {
       const pages: ISearchResult[] = [];
-      for await (const page of palCrawl.getAllPages(
+      for await (const page of palCrawl.getAllDonePages(
         { pageUnit: 5 },
         { maxPages: 4, delayMs: 0, concurrency: 2 },
       )) {
@@ -1347,6 +1348,50 @@ describe('NsmLmSts', () => {
           expect(item.progressStatus).toBe('발의');
         }
       }
+    });
+  });
+
+  // ── Screenshot functionality ──────────────────────────────────────────────
+
+  describe('Screenshot functionality', () => {
+    test('creates instance with screenshot config', () => {
+      const instance = new NsmLmSts({
+        screenshot: {
+          enabled: true,
+          fullPage: true,
+          width: 1280,
+          height: 800,
+          format: 'png',
+        },
+      });
+      expect(instance).toBeInstanceOf(NsmLmSts);
+    });
+
+    test('throws error when screenshot is disabled', async () => {
+      const instance = new NsmLmSts({ screenshot: { enabled: false } });
+      await expect(
+        instance.takeScreenshot('https://example.com'),
+      ).rejects.toThrow('Screenshot feature is not enabled');
+    });
+
+    test('accepts jpeg format with quality option', () => {
+      const instance = new NsmLmSts({
+        screenshot: { enabled: true, format: 'jpeg', quality: 85 },
+      });
+      expect(instance).toBeInstanceOf(NsmLmSts);
+    });
+
+    test('updateScreenshotConfig modifies screenshot settings', () => {
+      const instance = new NsmLmSts({
+        screenshot: { enabled: true, format: 'png' },
+      });
+      instance.updateScreenshotConfig({ format: 'jpeg', quality: 70 });
+      expect(instance).toBeInstanceOf(NsmLmSts);
+    });
+
+    test('initBrowser and closeBrowser can be called', async () => {
+      const instance = new NsmLmSts({ screenshot: { enabled: true } });
+      expect(instance).toBeInstanceOf(NsmLmSts);
     });
   });
 });

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -2,9 +2,12 @@ import {
   ITableData,
   ISearchResult,
   PalCrawl,
+  NsmLmSts,
   type PalCrawlConfig,
+  type INsmSearchResult,
+  type INsmBillItem,
 } from './pal';
-import { PalParser } from './parser';
+import { PalParser, NsmLmStsParser } from './parser';
 
 const DEFAULT_TEST_TIMEOUT_MS = 120000;
 const configuredTimeout = Number.parseInt(
@@ -159,6 +162,112 @@ const SEARCH_RESULT_HTML = `
       </td>
       <td></td>
       <td>1,234</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+// ─── NSM HTML Fixtures ────────────────────────────────────────────────────────
+
+/** 위원회에 배속된 법안 한 건 + 페이지네이션 */
+const NSM_LIST_HTML = `
+<p class="numBuild">총 <span>3,142</span>건</p>
+<p class="numBuild">현재 <em>2</em>/<span>315</span>쪽</p>
+<table>
+  <tbody>
+    <tr>
+      <td data-th="의안명">
+        <a href="/gcom/nsmLmSts/out/2219088/detailRP">인공지능 기본법 일부개정법률안</a>
+      </td>
+      <td data-th="제안자(제안일자)">
+        <p>홍길동의원 등 10인</p>
+        <p>(2026.05.01.)</p>
+      </td>
+      <td data-th="상임위원회(소관부처)">
+        <p>과학기술정보방송통신위원회</p>
+        <p>(과학기술정보통신부)</p>
+      </td>
+      <td data-th="국회현황(추진일자)">
+        <p>위원회 회부</p>
+        <p>(2026.05.03.)</p>
+      </td>
+      <td data-th="의결현황(의결일자)">
+        <p>원안가결</p>
+        <p>(2026.05.20.)</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+/** 위원회 회부 이전 발의 상태 법안 (committee 빈 문자열) */
+const NSM_LIST_HTML_PENDING = `
+<p class="numBuild">총 <span>87</span>건</p>
+<p class="numBuild">현재 <em>1</em>/<span>9</span>쪽</p>
+<table>
+  <tbody>
+    <tr>
+      <td data-th="의안명">
+        <a href="/gcom/nsmLmSts/out/2219200/detailRP">개인정보 보호법 일부개정법률안</a>
+      </td>
+      <td data-th="제안자(제안일자)">
+        <p>김철수의원 등 5인</p>
+        <p>(2026.05.28.)</p>
+      </td>
+      <td data-th="상임위원회(소관부처)">
+        <p>(개인정보보호위원회)</p>
+      </td>
+      <td data-th="국회현황(추진일자)">
+        <p>발의</p>
+        <p>(2026.05.28.)</p>
+      </td>
+      <td data-th="의결현황(의결일자)"></td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+/** 상세 페이지 */
+const NSM_DETAIL_HTML = `
+<h2></h2>
+<h2>인공지능 기본법 일부개정법률안</h2>
+<h3>기본정보</h3>
+<h3>국회입법현황</h3>
+<table>
+  <tbody>
+    <tr>
+      <th>발의정보</th>
+      <td>홍길동의원 등 10인, 제2219088호(2026. 5. 1.). 제435회 국회(임시회)</td>
+    </tr>
+    <tr>
+      <th>의안원문</th>
+      <td>
+        <button onclick="fnDownload(99001)">인공지능기본법안.hwp<span class="a11y_hidden">다운로드</span></button>
+        <button onclick="fnDownload(99002)">인공지능기본법안검토보고서.pdf<span class="a11y_hidden">다운로드</span></button>
+      </td>
+    </tr>
+    <tr>
+      <th>제안이유 및 주요내용</th>
+      <td>
+        <pre>인공지능 기술의 발전에 따라<br/>규제 체계를 정비하고자 함</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+/** 상세 페이지 — 제안이유 없음 (pre 태그 없는 경우) */
+const NSM_DETAIL_HTML_NO_REASON = `
+<h2>최소 법률안</h2>
+<table>
+  <tbody>
+    <tr>
+      <th>발의정보</th>
+      <td>이영희의원, 제2200001호(2026. 1. 5.). 제433회 국회(임시회)</td>
+    </tr>
+    <tr>
+      <th>의안원문</th>
       <td></td>
     </tr>
   </tbody>
@@ -552,10 +661,10 @@ describe('PalCrawl', () => {
     });
 
     test('search: billName filter returns matching items', async () => {
-      const result = await palCrawl.search({ billName: '도로교통' });
+      const result = await palCrawl.search({ billName: '개정법률' });
       expect(result.items.length).toBeGreaterThan(0);
       result.items.forEach((item) => {
-        expect(item.subject).toMatch(/도로교통/);
+        expect(item.subject).toMatch(/개정법률/);
       });
     });
 
@@ -707,7 +816,7 @@ describe('PalCrawl', () => {
     });
   });
 
-  // ── Screenshots ──────────────────────────────────────────────────────────────
+  // ── Screenshot functionality ─────────────────────────────────────────────────
 
   describe('Screenshot functionality', () => {
     test('creates instance with screenshot config', () => {
@@ -756,6 +865,488 @@ describe('PalCrawl', () => {
       // Note: These tests don't actually require a browser to pass.
       // In a real scenario with HEADLESS_BROWSER env set, these would work.
       expect(crawler).toBeInstanceOf(PalCrawl);
+    });
+  });
+});
+
+// ─── NsmLmStsParser ──────────────────────────────────────────────────────────
+
+describe('NsmLmStsParser', () => {
+  const parser = new NsmLmStsParser();
+
+  // ── parseList ──────────────────────────────────────────────────────────────
+
+  describe('parseList', () => {
+    test('returns empty result for empty string', () => {
+      const result = parser.parseList('');
+      expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.items).toHaveLength(0);
+    });
+
+    test('returns empty result for invalid html', () => {
+      const result = parser.parseList('not html at all');
+      expect(result.items).toHaveLength(0);
+    });
+
+    test('parses pagination: total, totalPages, currentPage', () => {
+      const result = parser.parseList(NSM_LIST_HTML);
+      expect(result.total).toBe(3142);
+      expect(result.totalPages).toBe(315);
+      expect(result.currentPage).toBe(2);
+    });
+
+    test('parses bill name and link', () => {
+      const result = parser.parseList(NSM_LIST_HTML);
+      expect(result.items).toHaveLength(1);
+      const item = result.items[0];
+      expect(item.billName).toBe('인공지능 기본법 일부개정법률안');
+      expect(item.billNo).toBe('2219088');
+      expect(item.link).toContain('2219088/detailRP');
+    });
+
+    test('parses proposer and proposalDate (strips parentheses)', () => {
+      const item = parser.parseList(NSM_LIST_HTML).items[0];
+      expect(item.proposer).toBe('홍길동의원 등 10인');
+      expect(item.proposalDate).toBe('2026.05.01.');
+    });
+
+    test('parses committee and ministry', () => {
+      const item = parser.parseList(NSM_LIST_HTML).items[0];
+      expect(item.committee).toBe('과학기술정보방송통신위원회');
+      expect(item.ministry).toBe('과학기술정보통신부');
+    });
+
+    test('parses progressStatus and progressDate', () => {
+      const item = parser.parseList(NSM_LIST_HTML).items[0];
+      expect(item.progressStatus).toBe('위원회 회부');
+      expect(item.progressDate).toBe('2026.05.03.');
+    });
+
+    test('parses resolutionStatus and resolutionDate', () => {
+      const item = parser.parseList(NSM_LIST_HTML).items[0];
+      expect(item.resolutionStatus).toBe('원안가결');
+      expect(item.resolutionDate).toBe('2026.05.20.');
+    });
+
+    test('pending bill: committee is empty string, ministry is set', () => {
+      const item = parser.parseList(NSM_LIST_HTML_PENDING).items[0];
+      expect(item.committee).toBe('');
+      expect(item.ministry).toBe('개인정보보호위원회');
+    });
+
+    test('pending bill: resolutionStatus and resolutionDate are empty strings', () => {
+      const item = parser.parseList(NSM_LIST_HTML_PENDING).items[0];
+      expect(item.resolutionStatus).toBe('');
+      expect(item.resolutionDate).toBe('');
+    });
+
+    test('pending bill: progressStatus is "발의"', () => {
+      const item = parser.parseList(NSM_LIST_HTML_PENDING).items[0];
+      expect(item.progressStatus).toBe('발의');
+    });
+
+    test('falls back to items.length when pagination markup is absent', () => {
+      const minimalHtml = `
+        <table><tbody>
+          <tr>
+            <td data-th="의안명"><a href="/gcom/nsmLmSts/out/1/detailRP">A</a></td>
+            <td data-th="제안자(제안일자)"><p>홍길동</p><p>(2026.01.01.)</p></td>
+            <td data-th="상임위원회(소관부처)"></td>
+            <td data-th="국회현황(추진일자)"><p>발의</p></td>
+            <td data-th="의결현황(의결일자)"></td>
+          </tr>
+        </tbody></table>`;
+      const result = parser.parseList(minimalHtml);
+      expect(result.totalPages).toBe(1);
+      expect(result.total).toBe(1);
+      expect(result.currentPage).toBe(1);
+    });
+
+    test('skips rows without a bill name', () => {
+      const htmlNoName = `
+        <table><tbody>
+          <tr>
+            <td data-th="의안명"><a href="/gcom/nsmLmSts/out/1/detailRP"></a></td>
+            <td data-th="제안자(제안일자)"></td>
+            <td data-th="상임위원회(소관부처)"></td>
+            <td data-th="국회현황(추진일자)"></td>
+            <td data-th="의결현황(의결일자)"></td>
+          </tr>
+        </tbody></table>`;
+      expect(parser.parseList(htmlNoName).items).toHaveLength(0);
+    });
+  });
+
+  // ── parseDetail ────────────────────────────────────────────────────────────
+
+  describe('parseDetail', () => {
+    test('returns default empty object for empty string', () => {
+      const detail = parser.parseDetail('');
+      expect(detail.title).toBe('');
+      expect(detail.billNo).toBe('');
+      expect(detail.proposer).toBe('');
+      expect(detail.proposalDate).toBe('');
+      expect(detail.session).toBe('');
+      expect(detail.proposalInfo).toBe('');
+      expect(detail.proposalReason).toBeNull();
+      expect(detail.attachments).toHaveLength(0);
+    });
+
+    test('picks title h2 (skips empty h2; h3 elements are section headers)', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.title).toBe('인공지능 기본법 일부개정법률안');
+    });
+
+    test('parses proposalInfo raw text', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.proposalInfo).toContain('제2219088호');
+      expect(detail.proposalInfo).toContain('제435회 국회(임시회)');
+    });
+
+    test('extracts billNo from proposalInfo', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.billNo).toBe('2219088');
+    });
+
+    test('extracts proposer from proposalInfo', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.proposer).toBe('홍길동의원 등 10인');
+    });
+
+    test('extracts proposalDate from proposalInfo', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.proposalDate).toBe('2026. 5. 1.');
+    });
+
+    test('extracts session from proposalInfo', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.session).toBe('제435회 국회(임시회)');
+    });
+
+    test('parses attachments: fileId and filename (strips a11y_hidden span)', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.attachments).toHaveLength(2);
+      expect(detail.attachments[0].fileId).toBe('99001');
+      expect(detail.attachments[0].filename).toBe('인공지능기본법안.hwp');
+      expect(detail.attachments[1].fileId).toBe('99002');
+      expect(detail.attachments[1].filename).toBe(
+        '인공지능기본법안검토보고서.pdf',
+      );
+    });
+
+    test('parses proposalReason from pre tag (br → newline)', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.proposalReason).toBe(
+        '인공지능 기술의 발전에 따라\n규제 체계를 정비하고자 함',
+      );
+    });
+
+    test('returns null proposalReason when pre tag is absent', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML_NO_REASON);
+      expect(detail.proposalReason).toBeNull();
+    });
+
+    test('returns empty attachments when no buttons are present', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML_NO_REASON);
+      expect(detail.attachments).toHaveLength(0);
+    });
+
+    test('single-proposer format parses without crash', () => {
+      const detail = parser.parseDetail(NSM_DETAIL_HTML_NO_REASON);
+      expect(detail.proposer).toBe('이영희의원');
+      expect(detail.billNo).toBe('2200001');
+      expect(detail.session).toBe('제433회 국회(임시회)');
+    });
+  });
+});
+
+// ─── NsmLmSts ─────────────────────────────────────────────────────────────────
+
+describe('NsmLmSts', () => {
+  const nsm = new NsmLmSts();
+
+  // ── constructor ────────────────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    test('creates instance without config', () => {
+      expect(new NsmLmSts()).toBeInstanceOf(NsmLmSts);
+    });
+
+    test('creates instance with empty config object', () => {
+      expect(new NsmLmSts({})).toBeInstanceOf(NsmLmSts);
+    });
+
+    test('accepts custom userAgent', () => {
+      expect(new NsmLmSts({ userAgent: 'Custom Agent' })).toBeInstanceOf(
+        NsmLmSts,
+      );
+    });
+
+    test('accepts custom timeout and retryCount', () => {
+      expect(new NsmLmSts({ timeout: 5000, retryCount: 2 })).toBeInstanceOf(
+        NsmLmSts,
+      );
+    });
+
+    test('accepts custom headers', () => {
+      expect(
+        new NsmLmSts({ customHeaders: { 'Accept-Language': 'ko-KR' } }),
+      ).toBeInstanceOf(NsmLmSts);
+    });
+  });
+
+  // ── parseList / parseDetail (delegation) ──────────────────────────────────
+
+  describe('parseList (delegation)', () => {
+    test('delegates to NsmLmStsParser and returns INsmSearchResult', () => {
+      const result = nsm.parseList(NSM_LIST_HTML);
+      expect(result.total).toBe(3142);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].billName).toBe('인공지능 기본법 일부개정법률안');
+    });
+
+    test('returns empty result for empty html', () => {
+      const result = nsm.parseList('');
+      expect(result.items).toHaveLength(0);
+    });
+  });
+
+  describe('parseDetail (delegation)', () => {
+    test('delegates to NsmLmStsParser and returns INsmBillDetail', () => {
+      const detail = nsm.parseDetail(NSM_DETAIL_HTML);
+      expect(detail.title).toBe('인공지능 기본법 일부개정법률안');
+      expect(detail.billNo).toBe('2219088');
+      expect(detail.attachments).toHaveLength(2);
+    });
+  });
+
+  // ── getDetailHTML validation ───────────────────────────────────────────────
+
+  describe('getDetailHTML input validation', () => {
+    test('throws when billNo is empty string', async () => {
+      await expect(nsm.getDetailHTML('')).rejects.toThrow('billNo is required');
+    });
+
+    test('throws when billNo is whitespace only', async () => {
+      await expect(nsm.getDetailHTML('   ')).rejects.toThrow(
+        'billNo is required',
+      );
+    });
+  });
+
+  // ── search integration ────────────────────────────────────────────────────
+
+  describe('search (integration)', () => {
+    let searchResult: INsmSearchResult;
+
+    beforeAll(async () => {
+      searchResult = await nsm.search({ pageSize: 5 });
+      debugLog('nsm.search', searchResult);
+    });
+
+    test('returns non-garbled html string (getListHTML)', async () => {
+      const html = await nsm.getListHTML({ pageSize: 5 });
+      expect(typeof html).toBe('string');
+      expect(html.length).toBeGreaterThan(0);
+      expect(html).not.toContain('\ufffd');
+    });
+
+    test('returns INsmSearchResult with total > 0', () => {
+      expect(searchResult.total).toBeGreaterThan(0);
+      expect(searchResult.totalPages).toBeGreaterThan(0);
+      expect(searchResult.currentPage).toBe(1);
+    });
+
+    test('returns items with valid structure and no garbled text', () => {
+      expect(searchResult.items.length).toBeGreaterThan(0);
+      for (const item of searchResult.items) {
+        expect(item.billName).not.toContain('\ufffd');
+        expect(item.billNo).toMatch(/^\d+$/);
+        expect(item.link).toContain('/gcom/nsmLmSts/out/');
+        expect(item.proposer).not.toContain('\ufffd');
+        expect(item.proposer.length).toBeGreaterThan(0);
+        expect(item.proposalDate.length).toBeGreaterThan(0);
+        expect(item.progressStatus.length).toBeGreaterThan(0);
+      }
+    });
+
+    test('pageSize filter limits returned items', async () => {
+      const r5 = await nsm.search({ pageSize: 5 });
+      const r10 = await nsm.search({ pageSize: 10 });
+      expect(r5.items.length).toBeLessThanOrEqual(5);
+      expect(r10.items.length).toBeLessThanOrEqual(10);
+    });
+
+    test('pageIndex=2 returns different items from page 1', async () => {
+      const page1 = await nsm.search({ pageSize: 5, pageIndex: 1 });
+      const page2 = await nsm.search({ pageSize: 5, pageIndex: 2 });
+      expect(page1.items.length).toBeGreaterThan(0);
+      expect(page2.items.length).toBeGreaterThan(0);
+      expect(page1.items[0].billNo).not.toBe(page2.items[0].billNo);
+    });
+  });
+
+  // ── searchPending integration ─────────────────────────────────────────────
+
+  describe('searchPending (integration)', () => {
+    let pendingResult: INsmSearchResult;
+
+    beforeAll(async () => {
+      pendingResult = await nsm.searchPending({ pageSize: 5 });
+      debugLog('nsm.searchPending', pendingResult);
+    });
+
+    test('returns INsmSearchResult with valid structure', () => {
+      expect(typeof pendingResult.total).toBe('number');
+      expect(typeof pendingResult.totalPages).toBe('number');
+      expect(pendingResult.currentPage).toBe(1);
+    });
+
+    test('all returned bills have progressStatus "발의"', () => {
+      for (const item of pendingResult.items) {
+        expect(item.progressStatus).toBe('발의');
+      }
+    });
+
+    test('all pending bills have no resolutionStatus', () => {
+      for (const item of pendingResult.items) {
+        expect(item.resolutionStatus).toBe('');
+      }
+    });
+
+    test('no garbled text in pending bill names', () => {
+      for (const item of pendingResult.items) {
+        expect(item.billName).not.toContain('\ufffd');
+      }
+    });
+  });
+
+  // ── getPage / getDetail integration ───────────────────────────────────────
+
+  describe('getPage / getDetail (integration)', () => {
+    let firstBillNo: string;
+    let pageItems: INsmBillItem[];
+
+    beforeAll(async () => {
+      pageItems = await nsm.getPage(1, { pageSize: 5 });
+      firstBillNo = pageItems[0]?.billNo ?? '';
+      debugLog('nsm.getPage(1)', pageItems);
+    });
+
+    test('getPage(1): returns INsmBillItem array', () => {
+      expect(Array.isArray(pageItems)).toBe(true);
+      expect(pageItems.length).toBeGreaterThan(0);
+    });
+
+    test('getPage(2): returns different items from page 1', async () => {
+      const page2 = await nsm.getPage(2, { pageSize: 5 });
+      expect(page2.length).toBeGreaterThan(0);
+      expect(page2[0].billNo).not.toBe(pageItems[0].billNo);
+    });
+
+    test('getDetailHTML: returns non-empty, non-garbled html', async () => {
+      if (!firstBillNo) return;
+      const html = await nsm.getDetailHTML(firstBillNo);
+      expect(typeof html).toBe('string');
+      expect(html.length).toBeGreaterThan(0);
+      expect(html).not.toContain('\ufffd');
+    });
+
+    test('getDetail: returns INsmBillDetail with valid fields', async () => {
+      if (!firstBillNo) return;
+      const detail = await nsm.getDetail(firstBillNo);
+      debugLog('nsm.getDetail', detail);
+      expect(detail.title.length).toBeGreaterThan(0);
+      expect(detail.title).not.toContain('\ufffd');
+      expect(detail.billNo).toMatch(/^\d+$/);
+      expect(detail.proposer.length).toBeGreaterThan(0);
+      expect(detail.proposalDate.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── getAllPages / getAllPendingPages integration ───────────────────────────
+
+  describe('getAllPages / getAllPendingPages (integration)', () => {
+    test('getAllPages: yields exactly maxPages results', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPages(
+        { pageSize: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages).toHaveLength(2);
+      expect(pages[0].items.length).toBeGreaterThan(0);
+      expect(pages[1].items.length).toBeGreaterThan(0);
+    });
+
+    test('getAllPages: currentPage increments correctly', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPages(
+        { pageSize: 5 },
+        { maxPages: 3, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].currentPage).toBe(1);
+      expect(pages[1].currentPage).toBe(2);
+      expect(pages[2].currentPage).toBe(3);
+    });
+
+    test('getAllPages: total is consistent across pages', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPages(
+        { pageSize: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].total).toBe(pages[1].total);
+      expect(pages[0].totalPages).toBe(pages[1].totalPages);
+    });
+
+    test('getAllPages: page 2 items differ from page 1', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPages(
+        { pageSize: 5 },
+        { maxPages: 2, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages[0].items[0].billNo).not.toBe(pages[1].items[0].billNo);
+    });
+
+    test('getAllPages: concurrency > 1 yields pages in order', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPages(
+        { pageSize: 5 },
+        { maxPages: 4, delayMs: 0, concurrency: 2 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages).toHaveLength(4);
+      for (let i = 0; i < pages.length; i++) {
+        expect(pages[i].currentPage).toBe(i + 1);
+      }
+    });
+
+    test('getAllPendingPages: yields at least 1 page of pending bills', async () => {
+      const pages: INsmSearchResult[] = [];
+      for await (const page of nsm.getAllPendingPages(
+        { pageSize: 5 },
+        { maxPages: 1, delayMs: 0 },
+      )) {
+        pages.push(page);
+      }
+      expect(pages.length).toBeGreaterThanOrEqual(1);
+      // Every item must be in 발의 상태
+      for (const page of pages) {
+        for (const item of page.items) {
+          expect(item.progressStatus).toBe('발의');
+        }
+      }
     });
   });
 });

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -4,9 +4,13 @@ import { Config } from './config';
 import { HttpClient } from './http-client';
 import {
   PalParser,
+  NsmLmStsParser,
   type ITableData,
   type IContentData,
   type ISearchResult,
+  type INsmBillItem,
+  type INsmBillDetail,
+  type INsmSearchResult,
 } from './parser';
 
 export type {
@@ -14,6 +18,10 @@ export type {
   ITableData,
   IContentData,
   ISearchResult,
+  INsmAttachment,
+  INsmBillItem,
+  INsmBillDetail,
+  INsmSearchResult,
 } from './parser';
 
 export interface ScreenshotOptions {
@@ -399,6 +407,263 @@ export class PalCrawl {
     return this._getAllPagesImpl(
       (q) => this.searchDone(q),
       query ?? {},
+      options ?? {},
+    );
+  }
+}
+
+// ── 국민참여입법센터 국회입법현황 ─────────────────────────────────────────────
+
+/**
+ * 국회현황 코드
+ * - 900101: 발의 (위원회 회부 이전 대기 상태 포함)
+ * - 900102: 위원회 회부
+ * - 900103: 위원회 상정
+ * - 900104: 위원회 법안소위
+ * - 900105: 위원회 전체회의
+ * - 900106: 법사위 심사
+ * - 900107: 본회의 심의
+ * - 900108: 정부이송
+ * - 900109: 공포
+ */
+export type NsmProgressStatus =
+  | '900101'
+  | '900102'
+  | '900103'
+  | '900104'
+  | '900105'
+  | '900106'
+  | '900107'
+  | '900108'
+  | '900109';
+
+/**
+ * 발의구분 코드
+ * - 900201: 정부
+ * - 900202: 의원
+ * - 900203: 위원장
+ */
+export type NsmProposerType = '900201' | '900202' | '900203';
+
+/**
+ * 의결현황 코드
+ * - 902911: 수정가결
+ * - 902912: 원안가결
+ * - 902913: 부결
+ * - 902914: 대안반영폐기
+ * - 902915: 폐기
+ * - 902916: 임기만료폐기
+ * - 902917: 철회
+ */
+export type NsmResolutionStatus =
+  | '902911'
+  | '902912'
+  | '902913'
+  | '902914'
+  | '902915'
+  | '902916'
+  | '902917';
+
+export interface INsmSearchQuery {
+  pageIndex?: number;
+  /** 페이지당 건수 (10 | 20 | 50 | 100) */
+  pageSize?: number;
+  /** 제안대수 시작 (예: "22" → 제22대) */
+  sugCd?: string;
+  /** 제안대수 끝 */
+  endSugCd?: string;
+  /** 발의구분 */
+  sgtCls?: NsmProposerType;
+  /** 소관부처 코드 */
+  cptOfiOrgCd?: string;
+  /** 국회현황 */
+  rslRsltNmL?: NsmProgressStatus;
+  /** 의결현황 */
+  rslRsltNmR?: NsmResolutionStatus;
+  /** 상임위 (예: "법제사법위원회") */
+  scCptPpostCmt?: string;
+  /** 제안일자 시작 (YYYY-MM-DD) */
+  searchStDtNew?: string;
+  /** 제안일자 종료 (YYYY-MM-DD) */
+  searchEdDtNew?: string;
+  /** 제안자 */
+  scPpsUsr?: string;
+  /** 규제 신설·강화 해당 여지 법안만 조회 */
+  issLawitmYn?: 'Y';
+  /** 추진일자 시작 (YYYY-MM-DD) */
+  stDt?: string;
+  /** 추진일자 종료 (YYYY-MM-DD) */
+  edDt?: string;
+  /** 의안번호 또는 의안명 */
+  scBlNmSct?: string;
+  sortCol?: string;
+  sortOrder?: 'DESC' | 'ASC';
+}
+
+export class NsmLmSts {
+  private readonly httpClient: HttpClient;
+  private readonly parser: NsmLmStsParser;
+
+  constructor(
+    config?: Pick<
+      PalCrawlConfig,
+      'userAgent' | 'timeout' | 'retryCount' | 'customHeaders'
+    >,
+  ) {
+    this.httpClient = new HttpClient({
+      userAgent: config?.userAgent ?? Config.UserAgent,
+      timeout: config?.timeout ?? 10000,
+      retryCount: config?.retryCount ?? 3,
+      customHeaders: config?.customHeaders ?? {},
+    });
+    this.parser = new NsmLmStsParser();
+  }
+
+  private buildListUrl(query: INsmSearchQuery): URL {
+    const url = new URL(Config.NSM_LIST_URL, Config.NSM_DOMAIN);
+    const entries: Array<[string, string | number | undefined]> = [
+      ['pageIndex', query.pageIndex],
+      ['pageSize', query.pageSize],
+      ['sugCd', query.sugCd],
+      ['endSugCd', query.endSugCd],
+      ['sgtCls', query.sgtCls],
+      ['cptOfiOrgCd', query.cptOfiOrgCd],
+      ['rslRsltNmL', query.rslRsltNmL],
+      ['rslRsltNmR', query.rslRsltNmR],
+      ['scCptPpostCmt', query.scCptPpostCmt],
+      ['searchStDtNew', query.searchStDtNew],
+      ['searchEdDtNew', query.searchEdDtNew],
+      ['scPpsUsr', query.scPpsUsr],
+      ['issLawitmYn', query.issLawitmYn],
+      ['stDt', query.stDt],
+      ['edDt', query.edDt],
+      ['sortCol', query.sortCol],
+      ['sortOrder', query.sortOrder],
+    ];
+    if (query.scBlNmSct) {
+      url.searchParams.set('scBlNm', 'scBlNm_blNm');
+      entries.push(['scBlNmSct', query.scBlNmSct]);
+    }
+    for (const [key, value] of entries) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url;
+  }
+
+  /** 목록 페이지 HTML 반환 */
+  public async getListHTML(query: INsmSearchQuery = {}): Promise<string> {
+    const url = this.buildListUrl({ pageIndex: 1, ...query });
+    return this.httpClient.get(url);
+  }
+
+  public parseList(html: string): INsmSearchResult {
+    return this.parser.parseList(html);
+  }
+
+  public parseDetail(html: string): INsmBillDetail {
+    return this.parser.parseDetail(html);
+  }
+
+  /** 목록 검색 (필터 지원) */
+  public async search(query: INsmSearchQuery = {}): Promise<INsmSearchResult> {
+    const html = await this.getListHTML(query);
+    return this.parser.parseList(html);
+  }
+
+  /**
+   * 위원회 회부 이전 발의 상태인 법안만 조회 (rslRsltNmL=900101 고정).
+   * 소관부처·제안대수·날짜 등 나머지 필터는 그대로 적용됩니다.
+   */
+  public async searchPending(
+    query: Omit<INsmSearchQuery, 'rslRsltNmL'> = {},
+  ): Promise<INsmSearchResult> {
+    return this.search({ ...query, rslRsltNmL: '900101' });
+  }
+
+  /** 상세 페이지 HTML 반환 */
+  public async getDetailHTML(billNo: string): Promise<string> {
+    const normalized = billNo.trim();
+    if (!normalized) throw new Error('billNo is required');
+    const url = new URL(
+      `${Config.NSM_LIST_URL}/${normalized}/detailRP`,
+      Config.NSM_DOMAIN,
+    );
+    return this.httpClient.get(url);
+  }
+
+  /** 법안 상세 정보 조회 */
+  public async getDetail(billNo: string): Promise<INsmBillDetail> {
+    const html = await this.getDetailHTML(billNo);
+    return this.parser.parseDetail(html);
+  }
+
+  /** 특정 페이지의 법안 목록 조회 */
+  public async getPage(
+    pageIndex: number,
+    query: Omit<INsmSearchQuery, 'pageIndex'> = {},
+  ): Promise<INsmBillItem[]> {
+    const result = await this.search({ ...query, pageIndex });
+    return result.items;
+  }
+
+  private async *_getAllPagesImpl(
+    query: Omit<INsmSearchQuery, 'pageIndex'>,
+    options: IBulkOptions,
+  ): AsyncGenerator<INsmSearchResult> {
+    const delayMs = options.delayMs ?? 500;
+    const concurrency = Math.max(1, options.concurrency ?? 1);
+
+    const first = await this.search({ ...query, pageIndex: 1 });
+    yield first;
+
+    if (first.totalPages <= 1 || first.items.length === 0) return;
+
+    const maxPages = Math.min(
+      first.totalPages,
+      options.maxPages ?? first.totalPages,
+    );
+
+    for (let start = 2; start <= maxPages; start += concurrency) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+      const end = Math.min(start + concurrency - 1, maxPages);
+      const pageNums = Array.from(
+        { length: end - start + 1 },
+        (_, i) => start + i,
+      );
+      const results = await Promise.all(
+        pageNums.map((p) => this.search({ ...query, pageIndex: p })),
+      );
+      for (const result of results) {
+        yield result;
+        if (result.items.length === 0) return;
+      }
+    }
+  }
+
+  /**
+   * 전체 페이지를 순차적으로 yield하는 async generator.
+   * `IBulkOptions`로 딜레이·동시성·최대 페이지를 조절할 수 있습니다.
+   */
+  public getAllPages(
+    query?: Omit<INsmSearchQuery, 'pageIndex'>,
+    options?: IBulkOptions,
+  ): AsyncGenerator<INsmSearchResult> {
+    return this._getAllPagesImpl(query ?? {}, options ?? {});
+  }
+
+  /**
+   * 발의 상태(위원회 회부 전) 법안 전체를 페이지 단위로 yield합니다.
+   */
+  public getAllPendingPages(
+    query?: Omit<INsmSearchQuery, 'pageIndex' | 'rslRsltNmL'>,
+    options?: IBulkOptions,
+  ): AsyncGenerator<INsmSearchResult> {
+    return this._getAllPagesImpl(
+      { ...query, rslRsltNmL: '900101' },
       options ?? {},
     );
   }

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -166,17 +166,13 @@ export class PalCrawl extends ScreenshotBase {
     this.parser = new PalParser();
   }
 
-  /**
-   * Get a screenshot of the bill list page.
-   */
+  /** 진행 중인 입법예고 목록 페이지 스크린샷을 반환합니다. */
   public async getPalScreenshot(): Promise<Buffer> {
     const url = new URL(Config.LIST_URL, Config.DOMAIN);
     return this.takeScreenshot(url.toString());
   }
 
-  /**
-   * Get a screenshot of a specific bill content page.
-   */
+  /** 진행 중인 입법예고의 특정 법률안 상세 페이지 스크린샷을 반환합니다. */
   public async getContentScreenshot(id: string): Promise<Buffer> {
     const normalizedId = id.trim();
     if (!normalizedId) {
@@ -190,17 +186,13 @@ export class PalCrawl extends ScreenshotBase {
     return this.takeScreenshot(url.toString());
   }
 
-  /**
-   * Get a screenshot of the done bills list page.
-   */
+  /** 완료된 입법예고 목록 페이지 스크린샷을 반환합니다. */
   public async getDoneScreenshot(): Promise<Buffer> {
     const url = new URL(Config.DONE_LIST_URL, Config.DOMAIN);
     return this.takeScreenshot(url.toString());
   }
 
-  /**
-   * Get a screenshot of a specific done bill content page.
-   */
+  /** 완료된 입법예고의 특정 법률안 상세 페이지 스크린샷을 반환합니다. */
   public async getDoneContentScreenshot(id: string): Promise<Buffer> {
     const normalizedId = id.trim();
     if (!normalizedId) {
@@ -238,24 +230,29 @@ export class PalCrawl extends ScreenshotBase {
     return url;
   }
 
+  /** 진행 중인 입법예고 목록 페이지의 HTML을 반환합니다. */
   public async getPalHTML(): Promise<string> {
     const url = new URL(Config.LIST_URL, Config.DOMAIN);
     return this.httpClient.get(url);
   }
 
+  /** HTML에서 법률안 목록을 파싱하여 반환합니다. */
   public parseTable(html: string): ITableData[] {
     return this.parser.parseTable(html);
   }
 
+  /** HTML에서 법률안 상세 내용을 파싱하여 반환합니다. */
   public parseContent(html: string): IContentData {
     return this.parser.parseContent(html);
   }
 
+  /** 진행 중인 입법예고 목록의 첫 페이지를 반환합니다. */
   public async get(): Promise<ITableData[]> {
     const html = await this.getPalHTML();
     return this.parser.parseTable(html);
   }
 
+  /** ID로 진행 중인 입법예고의 법률안 상세 페이지 HTML을 반환합니다. */
   public async getContentHTML(id: string): Promise<string> {
     const normalizedId = id.trim();
     if (!normalizedId) {
@@ -264,27 +261,31 @@ export class PalCrawl extends ScreenshotBase {
 
     const url = new URL(Config.CONTENT_URL, Config.DOMAIN);
     url.searchParams.set('lgsltPaid', normalizedId);
-    // Keep compatibility with currently used query key on the website.
+    // 사이트에서 현재 사용 중인 쿼리 키 호환성 유지
     url.searchParams.set('lgsltPaId', normalizedId);
 
     return this.httpClient.get(url);
   }
 
+  /** ID로 진행 중인 입법예고의 법률안 상세 정보를 조회합니다. */
   public async getContent(id: string): Promise<IContentData> {
     const html = await this.getContentHTML(id);
     return this.parser.parseContent(html);
   }
 
+  /** 완료된 입법예고 목록 페이지의 HTML을 반환합니다. */
   public async getDoneHTML(): Promise<string> {
     const url = new URL(Config.DONE_LIST_URL, Config.DOMAIN);
     return this.httpClient.get(url);
   }
 
+  /** 완료된 입법예고 목록의 첫 페이지를 반환합니다. */
   public async getDone(): Promise<ITableData[]> {
     const html = await this.getDoneHTML();
     return this.parser.parseTable(html);
   }
 
+  /** ID로 완료된 입법예고의 법률안 상세 페이지 HTML을 반환합니다. */
   public async getDoneContentHTML(id: string): Promise<string> {
     const normalizedId = id.trim();
     if (!normalizedId) {
@@ -298,6 +299,7 @@ export class PalCrawl extends ScreenshotBase {
     return this.httpClient.get(url);
   }
 
+  /** ID로 완료된 입법예고의 법률안 상세 정보를 조회합니다. */
   public async getDoneContent(id: string): Promise<IContentData> {
     const html = await this.getDoneContentHTML(id);
     return this.parser.parseContent(html);
@@ -305,14 +307,14 @@ export class PalCrawl extends ScreenshotBase {
 
   // ── Search / Filter ──────────────────────────────────────────────────────────
 
-  /** Fetch ongoing notices with optional filters and return parsed result with metadata. */
+  /** 진행 중인 입법예고를 검색합니다. 필터를 지정하지 않으면 1페이지를 반환합니다. */
   public async search(query: ISearchQuery = {}): Promise<ISearchResult> {
     const url = this.buildListUrl(Config.LIST_URL, { pageIndex: 1, ...query });
     const html = await this.httpClient.get(url);
     return this.parser.parseSearchResult(html);
   }
 
-  /** Fetch done notices with optional filters and return parsed result with metadata. */
+  /** 완료된 입법예고를 검색합니다. 필터를 지정하지 않으면 1페이지를 반환합니다. */
   public async searchDone(query: ISearchQuery = {}): Promise<ISearchResult> {
     const url = this.buildListUrl(Config.DONE_LIST_URL, {
       pageIndex: 1,
@@ -324,7 +326,7 @@ export class PalCrawl extends ScreenshotBase {
 
   // ── Explicit page access ─────────────────────────────────────────────────────
 
-  /** Fetch a specific page of ongoing notices. */
+  /** 진행 중인 입법예고의 특정 페이지 목록을 반환합니다. */
   public async getPage(
     pageIndex: number,
     pageUnit?: number,
@@ -333,7 +335,7 @@ export class PalCrawl extends ScreenshotBase {
     return result.items;
   }
 
-  /** Fetch a specific page of done notices. */
+  /** 완료된 입법예고의 특정 페이지 목록을 반환합니다. */
   public async getDonePage(
     pageIndex: number,
     pageUnit?: number,
@@ -382,8 +384,8 @@ export class PalCrawl extends ScreenshotBase {
   }
 
   /**
-   * Async generator that yields every page of ongoing notices.
-   * Respects `IBulkOptions` for rate-limiting and concurrency.
+   * 진행 중인 입법예고 전체 페이지를 순차적으로 yield하는 async generator.
+   * `IBulkOptions`로 딜레이·동시성·최대 페이지를 조절할 수 있습니다.
    */
   public getAllPages(
     query?: Omit<ISearchQuery, 'pageIndex'>,
@@ -397,8 +399,8 @@ export class PalCrawl extends ScreenshotBase {
   }
 
   /**
-   * Async generator that yields every page of done notices.
-   * Respects `IBulkOptions` for rate-limiting and concurrency.
+   * 완료된 입법예고 전체 페이지를 순차적으로 yield하는 async generator.
+   * `IBulkOptions`로 딜레이·동시성·최대 페이지를 조절할 수 있습니다.
    */
   public getAllDonePages(
     query?: Omit<ISearchQuery, 'pageIndex'>,
@@ -554,10 +556,12 @@ export class NsmLmSts extends ScreenshotBase {
     return this.httpClient.get(url);
   }
 
+  /** HTML에서 법안 목록 검색 결과를 파싱하여 반환합니다. */
   public parseList(html: string): INsmSearchResult {
     return this.parser.parseList(html);
   }
 
+  /** HTML에서 법안 상세 정보를 파싱하여 반환합니다. */
   public parseDetail(html: string): INsmBillDetail {
     return this.parser.parseDetail(html);
   }

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -67,34 +67,26 @@ export interface IBulkOptions {
   maxPages?: number;
 }
 
-export class PalCrawl {
-  private readonly httpClient: HttpClient;
-  private readonly parser: PalParser;
+/**
+ * Puppeteer 기반 스크린샷 기능을 공유하는 베이스 클래스.
+ * `PalCrawl`과 `NsmLmSts` 양쪽에서 상속합니다.
+ */
+export abstract class ScreenshotBase {
   private browser: Browser | null = null;
-  private screenshotConfig: ScreenshotOptions;
+  protected screenshotConfig: ScreenshotOptions;
 
-  constructor(config?: PalCrawlConfig) {
-    this.httpClient = new HttpClient({
-      userAgent: config?.userAgent ?? Config.UserAgent,
-      timeout: config?.timeout ?? 10000,
-      retryCount: config?.retryCount ?? 3,
-      customHeaders: config?.customHeaders ?? {},
-    });
-    this.parser = new PalParser();
+  protected constructor(screenshot?: ScreenshotOptions) {
     this.screenshotConfig = {
-      enabled: config?.screenshot?.enabled ?? false,
-      fullPage: config?.screenshot?.fullPage ?? true,
-      width: config?.screenshot?.width ?? 1920,
-      height: config?.screenshot?.height ?? 1080,
-      format: config?.screenshot?.format ?? 'png',
-      quality: config?.screenshot?.quality ?? 80,
+      enabled: screenshot?.enabled ?? false,
+      fullPage: screenshot?.fullPage ?? true,
+      width: screenshot?.width ?? 1920,
+      height: screenshot?.height ?? 1080,
+      format: screenshot?.format ?? 'png',
+      quality: screenshot?.quality ?? 80,
     };
   }
 
-  /**
-   * Initialize the Puppeteer browser instance.
-   * Call this before taking screenshots if not already initialized.
-   */
+  /** Puppeteer 브라우저 인스턴스를 초기화합니다. */
   public async initBrowser(): Promise<void> {
     if (!this.browser) {
       this.browser = await puppeteer.launch({
@@ -104,10 +96,7 @@ export class PalCrawl {
     }
   }
 
-  /**
-   * Close the Puppeteer browser instance.
-   * Call this when done to free up resources.
-   */
+  /** Puppeteer 브라우저 인스턴스를 종료하고 리소스를 해제합니다. */
   public async closeBrowser(): Promise<void> {
     if (this.browser) {
       await this.browser.close();
@@ -115,10 +104,7 @@ export class PalCrawl {
     }
   }
 
-  /**
-   * Take a screenshot of a URL and return it as a Buffer.
-   * Initializes browser if not already done.
-   */
+  /** 주어진 URL의 스크린샷을 Buffer로 반환합니다. */
   public async takeScreenshot(urlStr: string): Promise<Buffer> {
     if (!this.screenshotConfig.enabled) {
       throw new Error(
@@ -154,6 +140,30 @@ export class PalCrawl {
     } finally {
       await page.close();
     }
+  }
+
+  /** 스크린샷 설정을 업데이트합니다. */
+  public updateScreenshotConfig(config: Partial<ScreenshotOptions>): void {
+    this.screenshotConfig = {
+      ...this.screenshotConfig,
+      ...config,
+    };
+  }
+}
+
+export class PalCrawl extends ScreenshotBase {
+  private readonly httpClient: HttpClient;
+  private readonly parser: PalParser;
+
+  constructor(config?: PalCrawlConfig) {
+    super(config?.screenshot);
+    this.httpClient = new HttpClient({
+      userAgent: config?.userAgent ?? Config.UserAgent,
+      timeout: config?.timeout ?? 10000,
+      retryCount: config?.retryCount ?? 3,
+      customHeaders: config?.customHeaders ?? {},
+    });
+    this.parser = new PalParser();
   }
 
   /**
@@ -202,16 +212,6 @@ export class PalCrawl {
     url.searchParams.set('lgsltPaId', normalizedId);
 
     return this.takeScreenshot(url.toString());
-  }
-
-  /**
-   * Update screenshot configuration.
-   */
-  public updateScreenshotConfig(config: Partial<ScreenshotOptions>): void {
-    this.screenshotConfig = {
-      ...this.screenshotConfig,
-      ...config,
-    };
   }
 
   private buildListUrl(base: string, query: ISearchQuery): URL {
@@ -500,16 +500,12 @@ export interface INsmSearchQuery {
   sortOrder?: 'DESC' | 'ASC';
 }
 
-export class NsmLmSts {
+export class NsmLmSts extends ScreenshotBase {
   private readonly httpClient: HttpClient;
   private readonly parser: NsmLmStsParser;
 
-  constructor(
-    config?: Pick<
-      PalCrawlConfig,
-      'userAgent' | 'timeout' | 'retryCount' | 'customHeaders'
-    >,
-  ) {
+  constructor(config?: PalCrawlConfig) {
+    super(config?.screenshot);
     this.httpClient = new HttpClient({
       userAgent: config?.userAgent ?? Config.UserAgent,
       timeout: config?.timeout ?? 10000,
@@ -666,5 +662,24 @@ export class NsmLmSts {
       { ...query, rslRsltNmL: '900101' },
       options ?? {},
     );
+  }
+
+  /** 국회입법현황 목록 페이지 스크린샷 */
+  public async getNsmListScreenshot(
+    query: Omit<INsmSearchQuery, 'pageIndex'> = {},
+  ): Promise<Buffer> {
+    const url = this.buildListUrl({ pageIndex: 1, ...query });
+    return this.takeScreenshot(url.toString());
+  }
+
+  /** 법안 상세 페이지 스크린샷 */
+  public async getDetailScreenshot(billNo: string): Promise<Buffer> {
+    const normalized = billNo.trim();
+    if (!normalized) throw new Error('billNo is required');
+    const url = new URL(
+      `${Config.NSM_LIST_URL}/${normalized}/detailRP`,
+      Config.NSM_DOMAIN,
+    );
+    return this.takeScreenshot(url.toString());
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -258,3 +258,260 @@ export class PalParser {
     };
   }
 }
+
+// ── 국민참여입법센터 국회입법현황 (opinion.lawmaking.go.kr) ───────────────────
+
+/** 의안원문 첨부 파일 정보 */
+export interface INsmAttachment {
+  filename: string;
+  /** fnDownload() 호출에 사용되는 파일 ID */
+  fileId: string;
+}
+
+/** 목록 페이지의 법안 한 건 */
+export interface INsmBillItem {
+  billName: string;
+  billNo: string;
+  link: string;
+  proposer: string;
+  proposalDate: string;
+  /** 상임위원회명 (위원회 회부 전이면 빈 문자열) */
+  committee: string;
+  /** 소관부처 */
+  ministry: string;
+  /** 국회현황 (예: "발의", "위원회 회부") */
+  progressStatus: string;
+  /** 추진일자 */
+  progressDate: string;
+  /** 의결현황 (예: "원안가결") */
+  resolutionStatus: string;
+  /** 의결일자 */
+  resolutionDate: string;
+}
+
+/** 상세 페이지의 법안 정보 */
+export interface INsmBillDetail {
+  title: string;
+  billNo: string;
+  /** 발의정보 원문 텍스트 */
+  proposalInfo: string;
+  proposer: string;
+  proposalDate: string;
+  /** 제안회기 (예: "제435회 국회(임시회)") */
+  session: string;
+  proposalReason: string | null;
+  attachments: INsmAttachment[];
+}
+
+/** 목록 검색 결과 */
+export interface INsmSearchResult {
+  total: number;
+  totalPages: number;
+  currentPage: number;
+  items: INsmBillItem[];
+}
+
+export class NsmLmStsParser {
+  private normalizeText(text: string): string {
+    return text
+      .replace(/\u00a0/g, ' ')
+      .replace(/\r/g, '')
+      .split('\n')
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  public parseList(html: string): INsmSearchResult {
+    const $ = cheerio.load(html);
+    const items: INsmBillItem[] = [];
+
+    $('table tbody tr').each((_, tr) => {
+      const $tr = $(tr);
+
+      const $billNameLink = $tr.find('td[data-th="의안명"]').find('a');
+      const billName = $billNameLink.text().trim();
+      if (!billName) return;
+
+      const href = $billNameLink.attr('href') ?? '';
+      const link = href ? Config.NSM_DOMAIN + href : '';
+      const billNoMatch = href.match(/\/(\d+)\/detailRP/);
+      const billNo = billNoMatch?.[1] ?? '';
+
+      const proposerPs = $tr
+        .find('td[data-th="제안자(제안일자)"]')
+        .find('p')
+        .map((_, p) => $(p).text().trim())
+        .get()
+        .filter(Boolean);
+      const proposer = proposerPs[0] ?? '';
+      const proposalDate = (proposerPs[1] ?? '').replace(/^\(|\)$/g, '').trim();
+
+      const committeePs = $tr
+        .find('td[data-th="상임위원회(소관부처)"]')
+        .find('p')
+        .map((_, p) => $(p).text().trim())
+        .get()
+        .filter(Boolean);
+      let committee = '';
+      let ministry = '';
+      for (const p of committeePs) {
+        if (p.startsWith('(') && p.endsWith(')')) {
+          ministry = p.slice(1, -1).trim();
+        } else {
+          committee = p;
+        }
+      }
+
+      const progressPs = $tr
+        .find('td[data-th="국회현황(추진일자)"]')
+        .find('p')
+        .map((_, p) => $(p).text().trim())
+        .get()
+        .filter(Boolean);
+      const progressStatus = progressPs[0] ?? '';
+      const progressDate = (progressPs[1] ?? '').replace(/^\(|\)$/g, '').trim();
+
+      const resolutionPs = $tr
+        .find('td[data-th="의결현황(의결일자)"]')
+        .find('p')
+        .map((_, p) => $(p).text().trim())
+        .get()
+        .filter(Boolean);
+      const resolutionStatus = resolutionPs[0] ?? '';
+      const resolutionDate = (resolutionPs[1] ?? '')
+        .replace(/^\(|\)$/g, '')
+        .trim();
+
+      items.push({
+        billName,
+        billNo,
+        link,
+        proposer,
+        proposalDate,
+        committee,
+        ministry,
+        progressStatus,
+        progressDate,
+        resolutionStatus,
+        resolutionDate,
+      });
+    });
+
+    let total = 0;
+    let currentPage = 1;
+    let totalPages = 0;
+
+    $('p.numBuild').each((_, el) => {
+      const $el = $(el);
+      const text = $el.text();
+      if (text.includes('건')) {
+        total = parseInt($el.find('span').text().replace(/,/g, ''), 10) || 0;
+      } else if (text.includes('쪽')) {
+        currentPage =
+          parseInt($el.find('em').text().replace(/,/g, ''), 10) || 1;
+        totalPages =
+          parseInt($el.find('span').text().replace(/,/g, ''), 10) || 0;
+      }
+    });
+
+    if (totalPages === 0 && items.length > 0) {
+      totalPages = 1;
+      total = total || items.length;
+    }
+
+    return { total, totalPages, currentPage, items };
+  }
+
+  public parseDetail(html: string): INsmBillDetail {
+    const $ = cheerio.load(html);
+
+    const title = $('h2')
+      .filter((_, el) => $(el).text().trim().length > 5)
+      .first()
+      .text()
+      .trim();
+
+    // 입법 기본정보 테이블 탐색
+    const $table = $('table')
+      .filter((_, el) => {
+        return (
+          $(el)
+            .find('th')
+            .filter((_, th) => /발의정보/.test($(th).text())).length > 0
+        );
+      })
+      .first();
+
+    const proposalInfo = this.normalizeText(
+      $table
+        .find('th')
+        .filter((_, th) => /발의정보/.test($(th).text()))
+        .closest('tr')
+        .find('td')
+        .text(),
+    );
+
+    // "홍길동의원 등 12인, 제2219088호(2026. 5. 29.). 제435회 국회(임시회)" 파싱
+    const billNoMatch = proposalInfo.match(/제(\d+)호/);
+    const billNo = billNoMatch?.[1] ?? '';
+
+    const proposalDateMatch = proposalInfo.match(/제\d+호\(([^)]+)\)/);
+    const proposalDate = proposalDateMatch?.[1]?.trim() ?? '';
+
+    const proposerMatch = proposalInfo.match(/^([^,]+),/);
+    const proposer = proposerMatch?.[1]?.trim() ?? '';
+
+    const sessionMatch = proposalInfo.match(/\.\s+(제\d+회\s*국회.*?)$/);
+    const session = sessionMatch?.[1]?.trim() ?? '';
+
+    // 의안원문 첨부파일
+    const $attachTd = $table
+      .find('th')
+      .filter((_, th) => /의안원문/.test($(th).text()))
+      .closest('tr')
+      .find('td');
+    const attachments: INsmAttachment[] = [];
+    $attachTd.find('button[onclick*="fnDownload"]').each((_, btn) => {
+      const onclick = $(btn).attr('onclick') ?? '';
+      const fileIdMatch = onclick.match(/fnDownload\((\d+)\)/);
+      if (fileIdMatch) {
+        const $btn = $(btn).clone();
+        $btn.find('span.a11y_hidden').remove();
+        const filename = $btn.text().trim();
+        attachments.push({ filename, fileId: fileIdMatch[1] });
+      }
+    });
+
+    // 제안이유 및 주요내용
+    const $reasonTd = $table
+      .find('th')
+      .filter((_, th) => /제안이유/.test($(th).text()))
+      .closest('tr')
+      .find('td');
+    let proposalReason: string | null = null;
+    if ($reasonTd.length) {
+      const $pre = $reasonTd.find('pre');
+      if ($pre.length) {
+        const clone = $pre.clone();
+        clone.find('br').replaceWith('\n');
+        const text = this.normalizeText(clone.text());
+        proposalReason = text || null;
+      } else {
+        const text = this.normalizeText($reasonTd.text());
+        proposalReason = text || null;
+      }
+    }
+
+    return {
+      title,
+      billNo,
+      proposalInfo,
+      proposer,
+      proposalDate,
+      session,
+      proposalReason,
+      attachments,
+    };
+  }
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -50,6 +50,7 @@ export class PalParser {
     }
   }
 
+  /** HTML에서 입법예고 목록 테이블을 파싱하여 반환합니다. */
   public parseTable(html: string): ITableData[] {
     const $ = cheerio.load(html);
     const body = $('body');
@@ -93,6 +94,7 @@ export class PalParser {
     return output;
   }
 
+  /** HTML에서 목록 검색 결과(페이지 정보 + 아이템)를 파싱하여 반환합니다. */
   public parseSearchResult(html: string): ISearchResult {
     const $ = cheerio.load(html);
     const items = this.parseTable(html);
@@ -200,6 +202,7 @@ export class PalParser {
     };
   }
 
+  /** HTML에서 법률안 상세 내용을 파싱하여 반환합니다. */
   public parseContent(html: string): IContentData {
     const $ = cheerio.load(html);
 
@@ -322,6 +325,7 @@ export class NsmLmStsParser {
       .join('\n');
   }
 
+  /** HTML에서 국회입법현황 목록을 파싱하여 반환합니다. */
   public parseList(html: string): INsmSearchResult {
     const $ = cheerio.load(html);
     const items: INsmBillItem[] = [];
@@ -423,6 +427,7 @@ export class NsmLmStsParser {
     return { total, totalPages, currentPage, items };
   }
 
+  /** HTML에서 법안 상세 정보를 파싱하여 반환합니다. */
   public parseDetail(html: string): INsmBillDetail {
     const $ = cheerio.load(html);
 


### PR DESCRIPTION
This pull request adds comprehensive support for crawling and parsing legislative bill data from the 국민참여입법센터 국회입법현황 (opinion.lawmaking.go.kr) in addition to the existing 국회입법예고 site. It introduces the new `NsmLmSts` class, associated types, and parsing logic, and updates the documentation and exports accordingly. The README is significantly expanded with detailed usage instructions and examples for the new functionality.

**Major new feature: 국민참여입법센터 국회입법현황 (NsmLmSts) support**

- **New crawler and parser for 국민참여입법센터:**  
  Introduces the `NsmLmSts` class and `NsmLmStsParser` for crawling and parsing legislative bill lists, details, and attachments from the 국민참여입법센터 국회입법현황. This includes support for filtering by bill status (such as pre-committee bills), and provides methods for searching, paginating, and retrieving bill details and screenshots. [[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR264-R522) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R4) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R22) [[4]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R8-R10)

- **New types for 국민참여입법센터 data:**  
  Defines and exports new TypeScript interfaces and enums (`INsmSearchQuery`, `INsmSearchResult`, `INsmBillItem`, `INsmBillDetail`, `INsmAttachment`, `NsmProgressStatus`, `NsmProposerType`, `NsmResolutionStatus`) for strong typing of the new data structures. [[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR264-R522) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R22)

**Documentation updates**

- **Extensive README additions:**  
  Expands the `README.md` with a new section for `NsmLmSts`, including configuration, type definitions, method documentation, and multiple usage examples for searching, pagination, detail retrieval, and screenshot functionality. This helps users quickly understand and utilize the new crawler. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R478-R765) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R931-R991)

**Exports and config**

- **Exports for new features:**  
  Updates `src/index.ts` to export the new `NsmLmSts` class, parser, and all related types, making them available to library consumers. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R4) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R22)

- **Configuration additions:**  
  Adds `NSM_DOMAIN` and `NSM_LIST_URL` constants to the `Config` enum for use by the new crawler.

**Parser improvements**

- **Documentation and clarity:**  
  Adds JSDoc comments to parsing methods in `PalParser` for improved clarity and maintainability. [[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR53) [[2]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR97) [[3]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR205)

---

**References:**  
[[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR264-R522) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R4) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R13-R22) [[4]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R8-R10) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R42) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R53) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R478-R765) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R931-R991) [[9]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR53) [[10]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR97) [[11]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eR205)