### PR TITLE
feat: hydrate truncated bill titles from detail page with concurrent request limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pal-crawl",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "국회입법예고(pal.assembly.go.kr)의 진행 중인 입법 예고 크롤러",
   "license": "MIT",
   "author": "vientorepublic",

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -1102,8 +1102,13 @@ describe('NsmLmSts', () => {
   describe('search title hydration', () => {
     test('skips detail requests when list title is not truncated', async () => {
       const instance = new NsmLmSts();
+      const httpClient = (
+        instance as unknown as {
+          httpClient: { get: (url: URL) => Promise<string> };
+        }
+      ).httpClient;
       const mockGet = jest
-        .spyOn((instance as any).httpClient, 'get')
+        .spyOn(httpClient, 'get')
         .mockImplementation(async (...args: unknown[]) => {
           const url = args[0] as URL;
           const urlString = url.toString();
@@ -1123,8 +1128,13 @@ describe('NsmLmSts', () => {
 
     test('uses detail html title when list title is truncated', async () => {
       const instance = new NsmLmSts();
+      const httpClient = (
+        instance as unknown as {
+          httpClient: { get: (url: URL) => Promise<string> };
+        }
+      ).httpClient;
       const mockGet = jest
-        .spyOn((instance as any).httpClient, 'get')
+        .spyOn(httpClient, 'get')
         .mockImplementation(async (...args: unknown[]) => {
           const url = args[0] as URL;
           const urlString = url.toString();
@@ -1143,8 +1153,13 @@ describe('NsmLmSts', () => {
 
     test('keeps list title when detail request fails', async () => {
       const instance = new NsmLmSts();
+      const httpClient = (
+        instance as unknown as {
+          httpClient: { get: (url: URL) => Promise<string> };
+        }
+      ).httpClient;
       const mockGet = jest
-        .spyOn((instance as any).httpClient, 'get')
+        .spyOn(httpClient, 'get')
         .mockImplementation(async (...args: unknown[]) => {
           const url = args[0] as URL;
           const urlString = url.toString();

--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -228,6 +228,37 @@ const NSM_LIST_HTML_PENDING = `
 </table>
 `;
 
+/** 목록에서 제목이 잘린 케이스 */
+const NSM_LIST_HTML_TRUNCATED_TITLE = `
+<p class="numBuild">총 <span>1</span>건</p>
+<p class="numBuild">현재 <em>1</em>/<span>1</span>쪽</p>
+<table>
+  <tbody>
+    <tr>
+      <td data-th="의안명">
+        <a href="/gcom/nsmLmSts/out/2219088/detailRP">인공지능 기본법 일부개정...</a>
+      </td>
+      <td data-th="제안자(제안일자)">
+        <p>홍길동의원 등 10인</p>
+        <p>(2026.05.01.)</p>
+      </td>
+      <td data-th="상임위원회(소관부처)">
+        <p>과학기술정보방송통신위원회</p>
+        <p>(과학기술정보통신부)</p>
+      </td>
+      <td data-th="국회현황(추진일자)">
+        <p>위원회 회부</p>
+        <p>(2026.05.03.)</p>
+      </td>
+      <td data-th="의결현황(의결일자)">
+        <p>원안가결</p>
+        <p>(2026.05.20.)</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 /** 상세 페이지 */
 const NSM_DETAIL_HTML = `
 <h2></h2>
@@ -1067,6 +1098,69 @@ describe('NsmLmStsParser', () => {
 
 describe('NsmLmSts', () => {
   const nsm = new NsmLmSts();
+
+  describe('search title hydration', () => {
+    test('skips detail requests when list title is not truncated', async () => {
+      const instance = new NsmLmSts();
+      const mockGet = jest
+        .spyOn((instance as any).httpClient, 'get')
+        .mockImplementation(async (...args: unknown[]) => {
+          const url = args[0] as URL;
+          const urlString = url.toString();
+          if (urlString.includes('/detailRP')) {
+            throw new Error('detail should not be requested for full title');
+          }
+          return NSM_LIST_HTML;
+        });
+
+      const result = await instance.search({ pageSize: 1 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].billName).toBe('인공지능 기본법 일부개정법률안');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      mockGet.mockRestore();
+    });
+
+    test('uses detail html title when list title is truncated', async () => {
+      const instance = new NsmLmSts();
+      const mockGet = jest
+        .spyOn((instance as any).httpClient, 'get')
+        .mockImplementation(async (...args: unknown[]) => {
+          const url = args[0] as URL;
+          const urlString = url.toString();
+          if (urlString.includes('/detailRP')) {
+            return NSM_DETAIL_HTML;
+          }
+          return NSM_LIST_HTML_TRUNCATED_TITLE;
+        });
+
+      const result = await instance.search({ pageSize: 1 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].billName).toBe('인공지능 기본법 일부개정법률안');
+      mockGet.mockRestore();
+    });
+
+    test('keeps list title when detail request fails', async () => {
+      const instance = new NsmLmSts();
+      const mockGet = jest
+        .spyOn((instance as any).httpClient, 'get')
+        .mockImplementation(async (...args: unknown[]) => {
+          const url = args[0] as URL;
+          const urlString = url.toString();
+          if (urlString.includes('/detailRP')) {
+            throw new Error('detail fetch failed');
+          }
+          return NSM_LIST_HTML_TRUNCATED_TITLE;
+        });
+
+      const result = await instance.search({ pageSize: 1 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].billName).toBe('인공지능 기본법 일부개정...');
+      mockGet.mockRestore();
+    });
+  });
 
   // ── constructor ────────────────────────────────────────────────────────────
 

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -505,6 +505,7 @@ export interface INsmSearchQuery {
 export class NsmLmSts extends ScreenshotBase {
   private readonly httpClient: HttpClient;
   private readonly parser: NsmLmStsParser;
+  private readonly detailTitleConcurrency: number;
 
   constructor(config?: PalCrawlConfig) {
     super(config?.screenshot);
@@ -515,6 +516,65 @@ export class NsmLmSts extends ScreenshotBase {
       customHeaders: config?.customHeaders ?? {},
     });
     this.parser = new NsmLmStsParser();
+    this.detailTitleConcurrency = 4;
+  }
+
+  private isTruncatedBillName(billName: string): boolean {
+    return billName.includes('...') || billName.includes('…');
+  }
+
+  /**
+   * 목록의 잘린 제목을 상세 페이지 제목으로 보정합니다.
+   * 상세 조회 실패 시에는 기존 제목을 유지합니다.
+   */
+  private async hydrateBillNamesFromDetail(
+    items: INsmBillItem[],
+  ): Promise<INsmBillItem[]> {
+    if (items.length === 0) {
+      return items;
+    }
+
+    const normalizedConcurrency = Math.max(1, this.detailTitleConcurrency);
+    const hydrated = items.map((item) => ({ ...item }));
+    const truncatedItems = hydrated.filter((item) =>
+      this.isTruncatedBillName(item.billName),
+    );
+
+    if (truncatedItems.length === 0) {
+      return hydrated;
+    }
+
+    for (
+      let startIndex = 0;
+      startIndex < truncatedItems.length;
+      startIndex += normalizedConcurrency
+    ) {
+      const chunk = truncatedItems.slice(
+        startIndex,
+        startIndex + normalizedConcurrency,
+      );
+
+      await Promise.all(
+        chunk.map(async (item) => {
+          if (!item.billNo) {
+            return;
+          }
+
+          try {
+            const detailHtml = await this.getDetailHTML(item.billNo);
+            const detail = this.parser.parseDetail(detailHtml);
+            const detailTitle = detail.title.trim();
+            if (detailTitle) {
+              item.billName = detailTitle;
+            }
+          } catch {
+            // Keep list title when detail lookup fails.
+          }
+        }),
+      );
+    }
+
+    return hydrated;
   }
 
   private buildListUrl(query: INsmSearchQuery): URL {
@@ -569,7 +629,12 @@ export class NsmLmSts extends ScreenshotBase {
   /** 목록 검색 (필터 지원) */
   public async search(query: INsmSearchQuery = {}): Promise<INsmSearchResult> {
     const html = await this.getListHTML(query);
-    return this.parser.parseList(html);
+    const parsed = this.parser.parseList(html);
+    const items = await this.hydrateBillNamesFromDetail(parsed.items);
+    return {
+      ...parsed,
+      items,
+    };
   }
 
   /**


### PR DESCRIPTION
This pull request enhances the handling of bill titles that are truncated in the list view by hydrating them with the full title from the detail page when necessary. It also introduces robust test coverage for these scenarios and adds a concurrency limit for detail page requests.

**Bill Title Hydration Improvements:**

* Added a new method `hydrateBillNamesFromDetail` in `NsmLmSts` to detect truncated bill titles (ending with `...` or `…`) and fetch their full titles from the detail page, with graceful fallback if the detail fetch fails. Concurrency for these requests is limited to 4 at a time. [[1]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129R519-R577) [[2]](diffhunk://#diff-d3fc665b2388cfa5013e0a6e07482850c4af48e27f62f93a15a50a68dd69c129R508)
* Updated the `search` method in `NsmLmSts` to use `hydrateBillNamesFromDetail`, ensuring all bill titles in the result are as complete as possible.

**Testing Enhancements:**

* Added new test cases to `pal.test.ts` to cover scenarios where the bill title is not truncated, is truncated and successfully hydrated, or hydration fails (retaining the truncated title).
* Introduced a new HTML fixture `NSM_LIST_HTML_TRUNCATED_TITLE` for testing truncated title scenarios.

**Other:**

* Bumped the package version from `2.0.0` to `2.0.1` in `package.json` to reflect these improvements.