### PR TITLE
feat: Update initBrowser method to return Browser instance for additional Puppeteer operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ console.log(content);
 
 헤드리스 크로뮴(Puppeteer) 기반으로 웹페이지 스크린샷을 `Buffer`로 받을 수 있습니다.
 
-### initBrowser() => Promise\<void>
+### initBrowser() => Promise\<Browser>
 
-브라우저 인스턴스를 미리 초기화합니다. 스크린샷 호출 시 자동 초기화되므로 선택적으로 사용하면 됩니다.
+브라우저 인스턴스를 미리 초기화합니다. 반환되는 `Browser` 객체를 통해 추가적인 Puppeteer 작업을 수행할 수 있습니다. 스크린샷 호출 시 자동 초기화되므로 선택적으로 사용하면 됩니다.
 
 ### closeBrowser() => Promise\<void>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pal-crawl",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "국회입법예고(pal.assembly.go.kr)의 진행 중인 입법 예고 크롤러",
   "license": "MIT",
   "author": "vientorepublic",

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -87,13 +87,14 @@ export abstract class ScreenshotBase {
   }
 
   /** Puppeteer 브라우저 인스턴스를 초기화합니다. */
-  public async initBrowser(): Promise<void> {
+  public async initBrowser(): Promise<Browser> {
     if (!this.browser) {
       this.browser = await puppeteer.launch({
         headless: true,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
     }
+    return this.browser;
   }
 
   /** Puppeteer 브라우저 인스턴스를 종료하고 리소스를 해제합니다. */


### PR DESCRIPTION
This pull request introduces a minor enhancement to the browser initialization logic and updates documentation and versioning to match. The main change is that the `initBrowser` method now returns the Puppeteer `Browser` instance, allowing for more flexible usage.

Enhancements to browser initialization:

* Changed the return type of `initBrowser` in `ScreenshotBase` (in `src/pal.ts`) to return a `Browser` object instead of `void`, and updated the method to return the browser instance.

Documentation updates:

* Updated the `README.md` to clarify that `initBrowser()` returns a `Browser` object, and described how this can be used for additional Puppeteer tasks.

Versioning:

* Bumped the package version from `2.0.1` to `2.0.2` in `package.json`.