### PR TITLE
feat: Update initBrowser method to return void and make browser property public

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ console.log(content);
 
 헤드리스 크로뮴(Puppeteer) 기반으로 웹페이지 스크린샷을 `Buffer`로 받을 수 있습니다.
 
-### initBrowser() => Promise\<Browser>
+### initBrowser() => Promise\<void>
 
-브라우저 인스턴스를 미리 초기화합니다. 반환되는 `Browser` 객체를 통해 추가적인 Puppeteer 작업을 수행할 수 있습니다. 스크린샷 호출 시 자동 초기화되므로 선택적으로 사용하면 됩니다.
+브라우저 인스턴스를 미리 초기화합니다. 스크린샷 호출 시 자동 초기화되므로 선택적으로 사용하면 됩니다.
 
 ### closeBrowser() => Promise\<void>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pal-crawl",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pal-crawl",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "국회입법예고(pal.assembly.go.kr)의 진행 중인 입법 예고 크롤러",
   "license": "MIT",
   "author": "vientorepublic",

--- a/src/pal.ts
+++ b/src/pal.ts
@@ -72,7 +72,7 @@ export interface IBulkOptions {
  * `PalCrawl`과 `NsmLmSts` 양쪽에서 상속합니다.
  */
 export abstract class ScreenshotBase {
-  private browser: Browser | null = null;
+  public browser: Browser | null = null;
   protected screenshotConfig: ScreenshotOptions;
 
   protected constructor(screenshot?: ScreenshotOptions) {
@@ -87,14 +87,13 @@ export abstract class ScreenshotBase {
   }
 
   /** Puppeteer 브라우저 인스턴스를 초기화합니다. */
-  public async initBrowser(): Promise<Browser> {
+  public async initBrowser(): Promise<void> {
     if (!this.browser) {
       this.browser = await puppeteer.launch({
         headless: true,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
     }
-    return this.browser;
   }
 
   /** Puppeteer 브라우저 인스턴스를 종료하고 리소스를 해제합니다. */


### PR DESCRIPTION
This pull request updates the screenshot browser initialization logic and documentation, and bumps the package version. The main change is that `initBrowser` now returns `void` instead of a `Browser` instance, reflecting a shift toward internal browser management. The browser instance is also made public, and related documentation is updated.

### API and Implementation Changes

* Changed the return type of `initBrowser` in `ScreenshotBase` from `Promise<Browser>` to `Promise<void>`, and removed the return statement to reflect internal browser management. (`src/pal.ts`)
* Changed the `browser` property in `ScreenshotBase` from `private` to `public` to allow external access if needed. (`src/pal.ts`)

### Documentation Updates

* Updated the `README.md` to reflect the new return type of `initBrowser` and removed mention of returning a `Browser` object. (`README.md`)

### Versioning

* Bumped the package version from `2.0.2` to `2.0.3` in `package.json`. (`package.json`)