### PR TITLE
feat: Enhance NsmLmStsParser to preserve line breaks in proposalReason

### DIFF
--- a/src/pal.test.ts
+++ b/src/pal.test.ts
@@ -1075,6 +1075,27 @@ describe('NsmLmStsParser', () => {
       );
     });
 
+    test('preserves blank lines in proposalReason', () => {
+      const html = `
+        <table>
+          <tbody>
+            <tr>
+              <th>발의정보</th>
+              <td>홍길동의원 등 10인, 제2219088호(2026. 5. 1.). 제435회 국회(임시회)</td>
+            </tr>
+            <tr>
+              <th>제안이유</th>
+              <td><pre>첫 번째 문장
+
+두 번째 문장</pre></td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      const detail = parser.parseDetail(html);
+      expect(detail.proposalReason).toBe('첫 번째 문장\n\n두 번째 문장');
+    });
+
     test('returns null proposalReason when pre tag is absent', () => {
       const detail = parser.parseDetail(NSM_DETAIL_HTML_NO_REASON);
       expect(detail.proposalReason).toBeNull();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -315,14 +315,21 @@ export interface INsmSearchResult {
 }
 
 export class NsmLmStsParser {
-  private normalizeText(text: string): string {
-    return text
-      .replace(/\u00a0/g, ' ')
-      .replace(/\r/g, '')
+  private normalizeText(
+    text: string,
+    options?: { preserveLineBreaks?: boolean },
+  ): string {
+    const normalized = text.replace(/\u00a0/g, ' ').replace(/\r/g, '');
+
+    const lines = normalized
       .split('\n')
-      .map((line) => line.replace(/\s+/g, ' ').trim())
-      .filter(Boolean)
-      .join('\n');
+      .map((line) => line.replace(/\s+/g, ' ').trim());
+
+    if (options?.preserveLineBreaks) {
+      return lines.join('\n');
+    }
+
+    return lines.filter(Boolean).join('\n');
   }
 
   /** HTML에서 국회입법현황 목록을 파싱하여 반환합니다. */
@@ -500,10 +507,14 @@ export class NsmLmStsParser {
       if ($pre.length) {
         const clone = $pre.clone();
         clone.find('br').replaceWith('\n');
-        const text = this.normalizeText(clone.text());
+        const text = this.normalizeText(clone.text(), {
+          preserveLineBreaks: true,
+        });
         proposalReason = text || null;
       } else {
-        const text = this.normalizeText($reasonTd.text());
+        const text = this.normalizeText($reasonTd.text(), {
+          preserveLineBreaks: true,
+        });
         proposalReason = text || null;
       }
     }


### PR DESCRIPTION
This pull request improves the handling of line breaks in the `proposalReason` field when parsing legislative proposal details. The main change ensures that blank lines (multiple consecutive line breaks) are preserved in the parsed output, which is especially important for correctly displaying formatted text.

### Proposal reason parsing improvements

* Updated the `normalizeText` method in `NsmLmStsParser` to accept an options parameter, allowing preservation of line breaks and blank lines when requested.
* Modified proposal reason extraction to call `normalizeText` with `{ preserveLineBreaks: true }`, ensuring blank lines are preserved in both `<pre>` and non-`<pre>` cases.

### Testing

* Added a test to verify that blank lines in `proposalReason` are preserved after parsing, ensuring the new behavior is covered.